### PR TITLE
Watch imports that are not emitted

### DIFF
--- a/test/importWatch/app.ts
+++ b/test/importWatch/app.ts
@@ -1,0 +1,5 @@
+import { Something } from "./something";
+
+var a: Something = {
+	foo: 'bar'
+}

--- a/test/importWatch/expectedOutput/bundle.js
+++ b/test/importWatch/expectedOutput/bundle.js
@@ -1,0 +1,53 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	var a = {
+	    foo: 'bar'
+	};
+
+
+/***/ }
+/******/ ]);

--- a/test/importWatch/expectedOutput/output.transpiled.txt
+++ b/test/importWatch/expectedOutput/output.transpiled.txt
@@ -1,0 +1,4 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.42 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 28 bytes [rendered]
+    [0] ./.test/importWatch/app.ts 28 bytes {0} [built]

--- a/test/importWatch/expectedOutput/output.txt
+++ b/test/importWatch/expectedOutput/output.txt
@@ -1,0 +1,9 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.42 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 28 bytes [rendered]
+    [0] ./.test/importWatch/app.ts 28 bytes {0} [built] [1 error]
+
+ERROR in ./.test/importWatch/app.ts
+[37m([39m[36m3[39m,[36m5[39m): [31merror TS2322: Type '{ foo: string; }' is not assignable to type 'Something'.
+  Types of property 'foo' are incompatible.
+    Type 'string' is not assignable to type 'number'.[39m

--- a/test/importWatch/patch0/something.ts
+++ b/test/importWatch/patch0/something.ts
@@ -1,0 +1,3 @@
+export interface Something {
+	foo: string;
+}

--- a/test/importWatch/something.ts
+++ b/test/importWatch/something.ts
@@ -1,0 +1,3 @@
+export interface Something {
+	foo: number;
+}

--- a/test/importWatch/tsconfig.json
+++ b/test/importWatch/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		
+	},
+	"files": [
+	]
+}

--- a/test/importWatch/webpack.config.js
+++ b/test/importWatch/webpack.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+    entry: './app.ts',
+    output: {
+        filename: 'bundle.js'
+    },
+    resolve: {
+        extensions: ['', '.ts', '.js']
+    },
+    module: {
+        loaders: [
+            { test: /\.ts$/, loader: 'ts-loader' }
+        ]
+    }
+}
+
+// for test harness purposes only, you would not need this in a normal project
+module.exports.resolveLoader = { alias: { 'ts-loader': require('path').join(__dirname, "../../index.js") } }


### PR DESCRIPTION
There is a bug where if you use an import that is not emitted that import is not watched by webpack and any updates to it will not be reflected when watching.

This is just a test for the moment for documentation purposes. I'll add a fix at a later date. I've looked at this a little bit already and my current thinking is to use preProcessFile to get a list of imports and adding them as a dependency so that they'll be watched.