### PR TITLE
ignoreDiagnostics feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ of this.
 If true, no console.log messages will be emitted. Note that most error
 messages are emitted via webpack which is not affected by this flag.
 
+##### ignoreDiagnostics *(number[]) (default=[])*
+
+You can squelch certain TypeScript errors by specifying an array of diagnostic
+codes to ignore. 
+
 ##### compiler *(string) (default='typescript')*
 
 Allows use of TypeScript compilers other than the official one. Should be

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/TypeStrong/ts-loader",
   "dependencies": {
+    "arrify": "^1.0.0",
     "colors": "^1.0.3",
     "enhanced-resolve": "^0.9.0",
     "loader-utils": "^0.2.6",

--- a/test/ignoreDiagnostics/app.ts
+++ b/test/ignoreDiagnostics/app.ts
@@ -1,0 +1,11 @@
+export class Foo {
+	
+}
+
+class Bar {
+	
+}
+
+var a: Number = 'b'; // this should error with 2322
+
+export = Bar; // this should error with 2309 but doesn't since we ignore

--- a/test/ignoreDiagnostics/expectedOutput/bundle.js
+++ b/test/ignoreDiagnostics/expectedOutput/bundle.js
@@ -1,0 +1,63 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	var Foo = (function () {
+	    function Foo() {
+	    }
+	    return Foo;
+	})();
+	exports.Foo = Foo;
+	var Bar = (function () {
+	    function Bar() {
+	    }
+	    return Bar;
+	})();
+	var a = 'b'; // this should error with 2322
+	module.exports = Bar;
+
+
+/***/ }
+/******/ ]);

--- a/test/ignoreDiagnostics/expectedOutput/output.transpiled.txt
+++ b/test/ignoreDiagnostics/expectedOutput/output.transpiled.txt
@@ -1,0 +1,4 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.63 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 233 bytes [rendered]
+    [0] ./.test/ignoreDiagnostics/app.ts 233 bytes {0} [built]

--- a/test/ignoreDiagnostics/expectedOutput/output.txt
+++ b/test/ignoreDiagnostics/expectedOutput/output.txt
@@ -1,0 +1,8 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.63 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 233 bytes [rendered]
+    [0] ./.test/ignoreDiagnostics/app.ts 233 bytes {0} [built] [1 error]
+
+ERROR in ./.test/ignoreDiagnostics/app.ts
+[37m([39m[36m9[39m,[36m5[39m): [31merror TS2322: Type 'string' is not assignable to type 'Number'.
+  Property 'toFixed' is missing in type 'String'.[39m

--- a/test/ignoreDiagnostics/webpack.config.js
+++ b/test/ignoreDiagnostics/webpack.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+    entry: './app.ts',
+    output: {
+        filename: 'bundle.js'
+    },
+    resolve: {
+        extensions: ['', '.ts', '.js']
+    },
+    module: {
+        loaders: [
+            { test: /\.ts$/, loader: 'ts-loader' }
+        ]
+    },
+    ts: {
+        ignoreDiagnostics: [2309]
+    }
+}
+
+// for test harness purposes only, you would not need this in a normal project
+module.exports.resolveLoader = { alias: { 'ts-loader': require('path').join(__dirname, "../../index.js") } }

--- a/typings/arrify/arrify.d.ts
+++ b/typings/arrify/arrify.d.ts
@@ -1,0 +1,5 @@
+declare module 'arrify' {
+  function arrify <T> (arr: T | T[]): T[]
+
+  export = arrify
+}


### PR DESCRIPTION
This implements #60 

Note that there is an API change from typescript-simple-loader which named this option `ignoreWarnings`. I've opted for `ignoreDiagnostics` since it's more agnostic to warnings vs errors, but certainly open to feedback.

I shamelessly ripped some code from typescript-simple-loader for this. The basic idea is that I've added `loaderOptions` to the `instance` object (and made a partially hydrated `instance` object available earlier in the process). Then I changed the `formatErrors` function to take an instance object instead of the TypeScript compiler. This allows access to both the compiler and the ignoreWarnings option.

There was also some cleanup (as a separate commit) to help distinguish between loader options and compiler options in the code.

cc @blakeembrey @gdi2290