### PR TITLE
Typescript Api const enum over magic number on compile options

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -192,7 +192,7 @@ function ensureTypeScriptInstance(loaderOptions: LoaderOptions, loader: any): { 
     };
 
     var compilerOptions: typescript.CompilerOptions = {
-        module: 1 /* CommonJS */
+        module: typescript.ModuleKind.CommonJS /* CommonJS */
     };
 
     // Load any available tsconfig.json file
@@ -273,8 +273,8 @@ function ensureTypeScriptInstance(loaderOptions: LoaderOptions, loader: any): { 
     var libFileName = 'lib.d.ts';
 
     // Special handling for ES6 targets
-    if (compilerOptions.target == 2 /* ES6 */) {
-        compilerOptions.module = 0 /* None */;
+    if (compilerOptions.target == typescript.ScriptTarget.ES6 /* ES6 */) {
+        compilerOptions.module = typescript.ModuleKind.None /* None */;
         libFileName = 'lib.es6.d.ts';
     }
 
@@ -305,8 +305,8 @@ function ensureTypeScriptInstance(loaderOptions: LoaderOptions, loader: any): { 
     });
 
     let newLine =
-        compilerOptions.newLine === 0 /* CarriageReturnLineFeed */ ? '\r\n' :
-        compilerOptions.newLine === 1 /* LineFeed */ ? '\n' :
+        compilerOptions.newLine === typescript.NewLineKind.CarriageReturnLineFeed /* CarriageReturnLineFeed */ ? '\r\n' :
+        compilerOptions.newLine === typescript.NewLineKind.LineFeed /* LineFeed */ ? '\n' :
         os.EOL;
 
     // make a (sync) resolver that follows webpack's rules


### PR DESCRIPTION
Hi guys,

I was reading ts-loader source code recently and I stumbled upon some magic compile numbers.

It feels like we want to use the official typescript constants instead of some magic number.

This will allow to future proof us is case they change and feels easier to read.

Thanks for looking into it !
