### PR TITLE
Fix bug with webpack resolution

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -364,7 +364,7 @@ function ensureTypeScriptInstance(loaderOptions: LoaderOptions, loader: any): { 
                 let resolutionResult: any;
 
                 try {
-                    resolvedFileName = resolver.resolveSync(containingFile, moduleName)
+                    resolvedFileName = resolver.resolveSync(path.dirname(containingFile), moduleName)
 
                     if (!resolvedFileName.match(/\.tsx?$/)) resolvedFileName = null;
                     else resolutionResult = { resolvedFileName };

--- a/test/es6resolveParent/expectedOutput/bundle.js
+++ b/test/es6resolveParent/expectedOutput/bundle.js
@@ -1,0 +1,62 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	"use strict";
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+
+	function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+	var BaseComponent = function BaseComponent() {
+	  _classCallCheck(this, BaseComponent);
+	};
+
+	exports.BaseComponent = BaseComponent;
+
+/***/ }
+/******/ ]);

--- a/test/es6resolveParent/expectedOutput/output.txt
+++ b/test/es6resolveParent/expectedOutput/output.txt
@@ -1,0 +1,4 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.76 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 365 bytes [rendered]
+    [0] ./.test/es6resolveParent/index.tsx 365 bytes {0} [built]

--- a/test/es6resolveParent/index.tsx
+++ b/test/es6resolveParent/index.tsx
@@ -1,0 +1,3 @@
+import submodule from './submodule/index';
+
+export class BaseComponent {}

--- a/test/es6resolveParent/submodule/index.tsx
+++ b/test/es6resolveParent/submodule/index.tsx
@@ -1,0 +1,5 @@
+import { BaseComponent } from '../index';
+
+class Component extends BaseComponent {}
+
+export default 'foo';

--- a/test/es6resolveParent/tsconfig.json
+++ b/test/es6resolveParent/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"compilerOptions": {
+		"target": "es6",
+        "moduleResolution": "node",
+        "jsx": "react"
+	},
+	"files": [
+	]
+}

--- a/test/es6resolveParent/webpack.config.js
+++ b/test/es6resolveParent/webpack.config.js
@@ -1,0 +1,19 @@
+var path = require('path')
+
+module.exports = {
+    entry: './index',
+    output: {
+        filename: 'bundle.js'
+    },
+    resolve: {
+        extensions: ['', '.ts', '.tsx', '.js']
+    },
+    module: {
+        loaders: [
+            { test: /\.tsx?$/, loader: 'babel-loader!ts-loader' }
+        ]
+    }
+}
+
+// for test harness purposes only, you would not need this in a normal project
+module.exports.resolveLoader = { alias: { 'ts-loader': require('path').join(__dirname, "../../index.js") } }

--- a/test/issue92/app.ts
+++ b/test/issue92/app.ts
@@ -1,0 +1,3 @@
+import submodule from './submodule/submodule';
+
+export default submodule;

--- a/test/issue92/expectedOutput/bundle.js
+++ b/test/issue92/expectedOutput/bundle.js
@@ -1,0 +1,75 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+	Object.defineProperty(exports, '__esModule', {
+	  value: true
+	});
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+	var _submoduleSubmodule = __webpack_require__(1);
+
+	var _submoduleSubmodule2 = _interopRequireDefault(_submoduleSubmodule);
+
+	exports['default'] = _submoduleSubmodule2['default'];
+	module.exports = exports['default'];
+
+/***/ },
+/* 1 */
+/***/ function(module, exports) {
+
+	"use strict";
+
+	Object.defineProperty(exports, "__esModule", {
+	  value: true
+	});
+	exports["default"] = "Hello from submodule";
+	module.exports = exports["default"];
+
+/***/ }
+/******/ ]);

--- a/test/issue92/expectedOutput/output.txt
+++ b/test/issue92/expectedOutput/output.txt
@@ -1,0 +1,5 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  2.03 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 565 bytes [rendered]
+    [0] ./.test/issue92/app.ts 404 bytes {0} [built]
+    [1] ./.test/issue92/submodule/submodule.tsx 161 bytes {0} [built]

--- a/test/issue92/submodule/submodule.tsx
+++ b/test/issue92/submodule/submodule.tsx
@@ -1,0 +1,1 @@
+export default "Hello from submodule"

--- a/test/issue92/tsconfig.json
+++ b/test/issue92/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"target": "es6"
+	},
+	"files": [
+	]
+}

--- a/test/issue92/webpack.config.js
+++ b/test/issue92/webpack.config.js
@@ -1,0 +1,19 @@
+var path = require('path')
+
+module.exports = {
+    entry: './app',
+    output: {
+        filename: 'bundle.js'
+    },
+    resolve: {
+        extensions: ['', '.ts', '.tsx', '.js']
+    },
+    module: {
+        loaders: [
+            { test: /\.tsx?$/, loader: 'babel-loader!ts-loader' }
+        ]
+    }
+}
+
+// for test harness purposes only, you would not need this in a normal project
+module.exports.resolveLoader = { alias: { 'ts-loader': require('path').join(__dirname, "../../index.js") } }


### PR DESCRIPTION
This addresses #92. webpack resolution was not working correctly.

From that issue:

> So I've looked into this a bit and there are multiple cascading issues. The first issue is that there is a bug in ts-loader where the webpack lookup was failing (ts-loader first tries to resolve a file using webpack's resolution strategy). Since that was failing, the loader fell back on TypeScript's module resolution strategy. In this case TypeScript was unable to find the .tsx file because the `jsx` option was not specified in the compiler options, so that failed as well resulting in the "cannot find module" message. However, if you switched `moduleResolution` to `node` then TypeScript magically decided to include .tsx files in its lookup. Kind of weird if you ask me and possibly a bug that .tsx extension handling is done differently between the two strategies. In any case, by fixing the original bug the TypeScript resolution "bug" doesn't come into play.

The test here mimics the original issue of trying to import a `tsx` without specifying `jsx` or `moduleResolution`.