### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/TypeStrong/ts-loader.svg?branch=master)](https://travis-ci.org/TypeStrong/ts-loader)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/jbrantly/ts-loader?svg=true)](https://ci.appveyor.com/project/jbrantly/ts-loader)
 [![Downloads](http://img.shields.io/npm/dm/ts-loader.svg)](https://npmjs.org/package/ts-loader)
 [![Join the chat at https://gitter.im/TypeStrong/ts-loader](https://img.shields.io/badge/gitter-join%20chat-brightgreen.svg)](https://gitter.im/TypeStrong/ts-loader)
 


### PR DESCRIPTION
Added a link to the readme of the Appveyor build.  Because the [repo isn't public (?)](http://www.appveyor.com/docs/status-badges#badges-for-projects-with-public-repositories-on-github-and-bitbucket) the badge doesn't show up; but the link works just fine.  If you log into AppVeyor and go to this URL:

https://ci.appveyor.com/project/jbrantly/ts-loader/settings/badges

You should be able to get the badge from there.