### PR TITLE
Add support for emitting declaration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /*.js
+/*.d.ts
 /*.log
 *.js.map
 bundle.js

--- a/index.ts
+++ b/index.ts
@@ -569,6 +569,9 @@ function loader(contents) {
 
         var sourceMapFile = output.outputFiles.filter(file => !!file.name.match(/\.js(x?)\.map$/)).pop();
         if (sourceMapFile) { sourceMapText = sourceMapFile.text }
+        
+        var declarationFile = output.outputFiles.filter(file => !!file.name.match(/\.d.ts$/)).pop();
+        if (declarationFile) { this.emitFile(path.relative(this.options.context, declarationFile.name), declarationFile.text); }
     }
 
     if (outputText == null) throw new Error(`Typescript emitted no output for ${filePath}`);

--- a/package.json
+++ b/package.json
@@ -39,10 +39,11 @@
     "babel-loader": "^5.3.2",
     "escape-string-regexp": "^1.0.3",
     "fs-extra": "^0.22.1",
+    "glob": "^6.0.3",
     "mkdirp": "^0.5.1",
     "mocha": "^2.1.0",
     "rimraf": "^2.4.2",
-    "webpack": "^1.11.0",
-    "typescript": "^1.6.2"
+    "typescript": "^1.6.2",
+    "webpack": "^1.11.0"
   }
 }

--- a/test/declarationOutput/app.ts
+++ b/test/declarationOutput/app.ts
@@ -1,4 +1,6 @@
-class Test {
+import dep = require('./sub/dep');
+
+class Test extends dep {
 	doSomething() {
 		
 	}

--- a/test/declarationOutput/expectedOutput-1.6/app.d.ts
+++ b/test/declarationOutput/expectedOutput-1.6/app.d.ts
@@ -1,0 +1,5 @@
+import dep = require('./sub/dep');
+declare class Test extends dep {
+    doSomething(): void;
+}
+export = Test;

--- a/test/declarationOutput/expectedOutput-1.6/bundle.js
+++ b/test/declarationOutput/expectedOutput-1.6/bundle.js
@@ -42,6 +42,28 @@
 /************************************************************************/
 /******/ ([
 /* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var __extends = (this && this.__extends) || function (d, b) {
+	    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+	    function __() { this.constructor = d; }
+	    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+	};
+	var dep = __webpack_require__(1);
+	var Test = (function (_super) {
+	    __extends(Test, _super);
+	    function Test() {
+	        _super.apply(this, arguments);
+	    }
+	    Test.prototype.doSomething = function () {
+	    };
+	    return Test;
+	})(dep);
+	module.exports = Test;
+
+
+/***/ },
+/* 1 */
 /***/ function(module, exports) {
 
 	var Test = (function () {

--- a/test/declarationOutput/expectedOutput-1.6/output.txt
+++ b/test/declarationOutput/expectedOutput-1.6/output.txt
@@ -1,4 +1,7 @@
-    Asset     Size  Chunks             Chunk Names
-bundle.js  1.55 kB       0  [emitted]  main
-chunk    {0} bundle.js (main) 154 bytes [rendered]
-    [0] ./.test/declarationOutput/app.ts 154 bytes {0} [built]
+       Asset       Size  Chunks             Chunk Names
+    app.d.ts  110 bytes          [emitted]  
+sub/dep.d.ts   63 bytes          [emitted]  
+   bundle.js    2.16 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 675 bytes [rendered]
+    [0] ./.test/declarationOutput/app.ts 521 bytes {0} [built]
+    [1] ./.test/declarationOutput/sub/dep.ts 154 bytes {0} [built]

--- a/test/declarationOutput/expectedOutput-1.6/sub/dep.d.ts
+++ b/test/declarationOutput/expectedOutput-1.6/sub/dep.d.ts
@@ -1,0 +1,4 @@
+declare class Test {
+    doSomething(): void;
+}
+export = Test;

--- a/test/declarationOutput/expectedOutput-1.7/app.d.ts
+++ b/test/declarationOutput/expectedOutput-1.7/app.d.ts
@@ -1,0 +1,5 @@
+import dep = require('./sub/dep');
+declare class Test extends dep {
+    doSomething(): void;
+}
+export = Test;

--- a/test/declarationOutput/expectedOutput-1.7/bundle.js
+++ b/test/declarationOutput/expectedOutput-1.7/bundle.js
@@ -42,6 +42,28 @@
 /************************************************************************/
 /******/ ([
 /* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var __extends = (this && this.__extends) || function (d, b) {
+	    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+	    function __() { this.constructor = d; }
+	    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+	};
+	var dep = __webpack_require__(1);
+	var Test = (function (_super) {
+	    __extends(Test, _super);
+	    function Test() {
+	        _super.apply(this, arguments);
+	    }
+	    Test.prototype.doSomething = function () {
+	    };
+	    return Test;
+	})(dep);
+	module.exports = Test;
+
+
+/***/ },
+/* 1 */
 /***/ function(module, exports) {
 
 	var Test = (function () {

--- a/test/declarationOutput/expectedOutput-1.7/output.txt
+++ b/test/declarationOutput/expectedOutput-1.7/output.txt
@@ -1,4 +1,7 @@
-    Asset     Size  Chunks             Chunk Names
-bundle.js  1.55 kB       0  [emitted]  main
-chunk    {0} bundle.js (main) 154 bytes [rendered]
-    [0] ./.test/declarationOutput/app.ts 154 bytes {0} [built]
+       Asset       Size  Chunks             Chunk Names
+    app.d.ts  110 bytes          [emitted]  
+sub/dep.d.ts   63 bytes          [emitted]  
+   bundle.js    2.16 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 675 bytes [rendered]
+    [0] ./.test/declarationOutput/app.ts 521 bytes {0} [built]
+    [1] ./.test/declarationOutput/sub/dep.ts 154 bytes {0} [built]

--- a/test/declarationOutput/expectedOutput-1.7/sub/dep.d.ts
+++ b/test/declarationOutput/expectedOutput-1.7/sub/dep.d.ts
@@ -1,0 +1,4 @@
+declare class Test {
+    doSomething(): void;
+}
+export = Test;

--- a/test/declarationOutput/expectedOutput-1.8/app.d.ts
+++ b/test/declarationOutput/expectedOutput-1.8/app.d.ts
@@ -1,0 +1,5 @@
+import dep = require('./sub/dep');
+declare class Test extends dep {
+    doSomething(): void;
+}
+export = Test;

--- a/test/declarationOutput/expectedOutput-1.8/bundle.js
+++ b/test/declarationOutput/expectedOutput-1.8/bundle.js
@@ -42,6 +42,29 @@
 /************************************************************************/
 /******/ ([
 /* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	var __extends = (this && this.__extends) || function (d, b) {
+	    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+	    function __() { this.constructor = d; }
+	    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+	};
+	var dep = __webpack_require__(1);
+	var Test = (function (_super) {
+	    __extends(Test, _super);
+	    function Test() {
+	        _super.apply(this, arguments);
+	    }
+	    Test.prototype.doSomething = function () {
+	    };
+	    return Test;
+	}(dep));
+	module.exports = Test;
+
+
+/***/ },
+/* 1 */
 /***/ function(module, exports) {
 
 	"use strict";

--- a/test/declarationOutput/expectedOutput-1.8/output.txt
+++ b/test/declarationOutput/expectedOutput-1.8/output.txt
@@ -1,4 +1,7 @@
-    Asset     Size  Chunks             Chunk Names
-bundle.js  1.56 kB       0  [emitted]  main
-chunk    {0} bundle.js (main) 168 bytes [rendered]
-    [0] ./.test/declarationOutput/app.ts 168 bytes {0} [built]
+       Asset       Size  Chunks             Chunk Names
+    app.d.ts  110 bytes          [emitted]  
+sub/dep.d.ts   63 bytes          [emitted]  
+   bundle.js    2.19 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 703 bytes [rendered]
+    [0] ./.test/declarationOutput/app.ts 535 bytes {0} [built]
+    [1] ./.test/declarationOutput/sub/dep.ts 168 bytes {0} [built]

--- a/test/declarationOutput/expectedOutput-1.8/sub/dep.d.ts
+++ b/test/declarationOutput/expectedOutput-1.8/sub/dep.d.ts
@@ -1,0 +1,4 @@
+declare class Test {
+    doSomething(): void;
+}
+export = Test;

--- a/test/declarationOutput/sub/dep.ts
+++ b/test/declarationOutput/sub/dep.ts
@@ -1,0 +1,8 @@
+
+class Test {
+	doSomething() {
+		
+	}
+}
+
+export = Test;


### PR DESCRIPTION
This adds support for emitting `.d.ts` files when `declaration: true` is set in tsconfig. This brings ts-loader closer in-line with `tsc` behavior and allows other tools to possibly re-package the individual `.d.ts` files into a single one (outside the scope of this project, for now).

The test runner also had a minor update to support working with output in subdirectories.

This fixes #48.