### PR TITLE
Made tester mostly resilient to escaped windows end of lines

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -32,12 +32,12 @@ rimraf.sync(stagingPath);
 fs.readdirSync(__dirname).forEach(function(test) {
     var testPath = path.join(__dirname, test);
     if (fs.statSync(testPath).isDirectory()) {
-        
+
         if (test == 'issue81' && semver.lt(typescript.version, '1.7.0-0')) return;
-        
+
         describe(test, function() {
             it('should have the correct output', createTest(test, testPath, {}));
-            
+
             if (test == 'declarationOutput') { return; }
             if (test == 'declarationWatch') { return; }
             if (test == 'issue71') { return; }
@@ -61,14 +61,14 @@ function getFileContents(outputLocation, file) {
 function createTest(test, testPath, options) {
     return function(done) {
         this.timeout(60000); // sometimes it just takes awhile
-        
+
         // set up paths
         var testStagingPath = path.join(stagingPath, test+(options.transpile ? '.transpile' : '')),
             actualOutput = path.join(testStagingPath, 'actualOutput'),
             expectedOutput = path.join(testStagingPath, 'expectedOutput-'+typescriptVersion),
             webpackOutput = path.join(testStagingPath, '.output'),
             originalExpectedOutput = path.join(testPath, 'expectedOutput-'+typescriptVersion);
-        
+
         if (saveOutputMode) {
             savedOutputs[test] = savedOutputs[test] || {};
             var regularSavedOutput = savedOutputs[test].regular = savedOutputs[test].regular || {};
@@ -76,16 +76,16 @@ function createTest(test, testPath, options) {
             var currentSavedOutput = options.transpile ? transpiledSavedOutput : regularSavedOutput;
             mkdirp.sync(originalExpectedOutput);
         }
-        
+
         // copy all input to a staging area
         mkdirp.sync(testStagingPath);
         fs.copySync(testPath, testStagingPath);
-           
-            
+
+
         // ensure output directories
         mkdirp.sync(actualOutput);
         mkdirp.sync(webpackOutput);
-        
+
         // execute webpack
         var config = require(path.join(testStagingPath, 'webpack.config'));
         config.output.path = webpackOutput;
@@ -99,9 +99,9 @@ function createTest(test, testPath, options) {
         config.ts.compilerOptions = {
             newLine: 'LF'
         }
-        
+
         if (options.transpile) config.ts.transpileOnly = true;
-        
+
         var iteration = 0;
         var lastHash;
         var watcher = webpack(config).watch({aggregateTimeout: 1500}, function(err, stats) {
@@ -115,7 +115,7 @@ function createTest(test, testPath, options) {
                 mkdirp.sync(expectedOutput);
                 if (saveOutputMode) mkdirp.sync(originalExpectedOutput);
             }
-            
+
             // replace the hash if found in the output since it can change depending
             // on environments and we're not super interested in it
             if (stats) {
@@ -125,44 +125,44 @@ function createTest(test, testPath, options) {
                     fs.writeFileSync(path.join(webpackOutput, file), content);
                 });
             }
-            
+
             // output results
             if (saveOutputMode) {
                 // loop through webpackOutput and rename to .transpiled if needed
                 glob.sync('**/*', {cwd: webpackOutput, nodir: true}).forEach(function(file) {
                     var patchedFileName = patch+'/'+file;
                     currentSavedOutput[patchedFileName] = fs.readFileSync(path.join(webpackOutput, file), 'utf-8');
-                    
+
                     if (options.transpile) {
                         if (regularSavedOutput[patchedFileName] !== transpiledSavedOutput[patchedFileName]) {
                             var extension = path.extname(file);
                             fs.renameSync(
-                                path.join(webpackOutput, file), 
+                                path.join(webpackOutput, file),
                                 path.join(webpackOutput, path.basename(file, extension)+'.transpiled'+extension)
                             );
                         }
                     }
                 });
-                
+
                 fs.copySync(webpackOutput, originalExpectedOutput, { clobber: true });
             }
             fs.copySync(webpackOutput, actualOutput);
             rimraf.sync(webpackOutput);
-            
+
             if (err) {
                 var errFileName = 'err.txt';
-                
+
                 var errString = err.toString()
                     .replace(new RegExp(regexEscape(testStagingPath+path.sep), 'g'), '')
                     .replace(new RegExp(regexEscape(rootPath+path.sep), 'g'), '')
                     .replace(new RegExp(regexEscape(rootPath), 'g'), '')
                     .replace(/\.transpile/g, '');
-                
+
                 fs.writeFileSync(path.join(actualOutput, errFileName), errString);
                 if (saveOutputMode) {
                     var patchedErrFileName = patch+'/'+errFileName;
                     currentSavedOutput[patchedErrFileName] = errString;
-                    
+
                     if (options.transpile) {
                         if (regularSavedOutput[patchedErrFileName] !== transpiledSavedOutput[patchedErrFileName]) {
                             fs.writeFileSync(path.join(originalExpectedOutput, 'err.transpiled.txt'), errString);
@@ -173,31 +173,31 @@ function createTest(test, testPath, options) {
                     }
                 }
             }
-            
+
             if (stats && stats.hash != lastHash) {
                 lastHash = stats.hash;
-                
+
                 var statsFileName = 'output.txt';
-                
+
                 // do a little magic to normalize `\` to `/` for asset output
                 var newAssets = {};
-                Object.keys(stats.compilation.assets).forEach(function(asset) { 
-                    newAssets[asset.replace(/\\/g, "/")] = stats.compilation.assets[asset]; 
+                Object.keys(stats.compilation.assets).forEach(function(asset) {
+                    newAssets[asset.replace(/\\/g, "/")] = stats.compilation.assets[asset];
                 });
                 stats.compilation.assets = newAssets;
-                
+
                 var statsString = stats.toString({timings: false, version: false, hash: false})
                     .replace(new RegExp(regexEscape(testStagingPath+path.sep), 'g'), '')
                     .replace(new RegExp(regexEscape(rootPath+path.sep), 'g'), '')
                     .replace(new RegExp(regexEscape(rootPath), 'g'), '')
                     .replace(new RegExp(regexEscape(rootPathWithIncorrectWindowsSeparator), 'g'), '')
                     .replace(/\.transpile/g, '');
-                
+
                 fs.writeFileSync(path.join(actualOutput, statsFileName), statsString);
                 if (saveOutputMode) {
                     var patchedStatsFileName = patch+'/'+statsFileName;
                     currentSavedOutput[patchedStatsFileName] = statsString;
-                    
+
                     if (options.transpile) {
                         if (regularSavedOutput[patchedStatsFileName] !== transpiledSavedOutput[patchedStatsFileName]) {
                             fs.writeFileSync(path.join(originalExpectedOutput, 'output.transpiled.txt'), statsString);
@@ -208,7 +208,7 @@ function createTest(test, testPath, options) {
                     }
                 }
             }
-        
+
             if (!saveOutputMode) {
                 // massage any .transpiled. files
                 glob.sync('**/*', {cwd: expectedOutput, nodir: true}).forEach(function(file) {
@@ -216,7 +216,7 @@ function createTest(test, testPath, options) {
                         if (options.transpile) { // rename if we're in transpile mode
                             var extension = path.extname(file);
                             fs.renameSync(
-                                path.join(expectedOutput, file), 
+                                path.join(expectedOutput, file),
                                 path.join(expectedOutput, path.dirname(file), path.basename(file, '.transpiled'+extension)+extension)
                             );
                         }
@@ -226,29 +226,28 @@ function createTest(test, testPath, options) {
 
                     }
                 });
-                
+
                 // compare actual to expected
                 var actualFiles = glob.sync('**/*', {cwd: actualOutput, nodir: true}),
                     expectedFiles = glob.sync('**/*', {cwd: expectedOutput, nodir: true})
                         .filter(function(file) { return !/^patch/.test(file); }),
                     allFiles = {};
-                        
+
                 actualFiles.map(function(file) { allFiles[file] = true });
                 expectedFiles.map(function(file) { allFiles[file] = true });
-                
+
                 Object.keys(allFiles).forEach(function(file) {
                     var actual = getFileContents(actualOutput, file);
-                    var expected = getFileContents(expectedOutput, file);
-                    
+                    var expected = getFileContents(expectedOutput, file);              
                     assert.equal(actual.toString(), expected.toString(), (patch?patch+'/':patch) + file + ' is different between actual and expected');
                 });
             }
-            
+
             // check for new files to copy in
             var patchPath = path.join(testStagingPath, 'patch'+iteration);
             if (fs.existsSync(patchPath)) {
                 iteration++;
-                
+
                 // can get inconsistent results if copying right away
                 setTimeout(function() {
                     fs.copySync(patchPath, testStagingPath, {clobber: true});

--- a/test/run.js
+++ b/test/run.js
@@ -46,6 +46,18 @@ fs.readdirSync(__dirname).forEach(function(test) {
     }
 });
 
+function getFileContents(outputLocation, file) {
+    var contents, fileLocation;
+    try {
+        fileLocation = path.join(outputLocation, file);
+        contents = fs.readFileSync(fileLocation, 'utf8')
+            .replace(/\\r\\n/g, '\\n') // Handle escaped windows end of lines
+            .replace(/\r\n/g, '\n');   // and un-escaped windows end of lines
+    }
+    catch (e) { contents = '!!!' + fileLocation + ' file doesnt exist!!!' }
+    return contents;
+}
+
 function createTest(test, testPath, options) {
     return function(done) {
         this.timeout(60000); // sometimes it just takes awhile
@@ -225,15 +237,8 @@ function createTest(test, testPath, options) {
                 expectedFiles.map(function(file) { allFiles[file] = true });
                 
                 Object.keys(allFiles).forEach(function(file) {
-                    try {
-                        var actual = fs.readFileSync(path.join(actualOutput, file)).toString().replace(/\r\n/g, '\n');
-                    }
-                    catch (e) { actual = '!!!actual file doesnt exist!!!' }
-                    
-                    try {
-                        var expected = fs.readFileSync(path.join(expectedOutput, file)).toString().replace(/\r\n/g, '\n');
-                    }
-                    catch (e) { expected = '!!!expected file doesnt exist!!!' }
+                    var actual = getFileContents(actualOutput, file);
+                    var expected = getFileContents(expectedOutput, file);
                     
                     assert.equal(actual.toString(), expected.toString(), (patch?patch+'/':patch) + file + ' is different between actual and expected');
                 });


### PR DESCRIPTION
Whether you want to take this PR or not is arguable.  I say that as while it makes the test reporter more resilient it leaves one problem unhandled. That is to say this:

```
  63 passing (1m)
  2 failing

  1) issue81 should have the correct output:

      Uncaught AssertionError: output.txt is different between actual and expected
      + expected - actual

               Asset     Size  Chunks             Chunk Names
           bundle.js  2.42 kB       0  [emitted]  main
      -bundle.js.map  2.54 kB       0  [emitted]  main
      +bundle.js.map  2.53 kB       0  [emitted]  main
       chunk    {0} bundle.js, bundle.js.map (main) 896 bytes [rendered]
           [0] ./.test/issue81/a.ts 896 bytes {0} [built]

      at C:\source\ts-loader\test\run.js:243:28
      at Array.forEach (native)
      at Watching.handler (C:\source\ts-loader\test\run.js:239:39)
      at Watching._done (C:\source\ts-loader\node_modules\webpack\lib\Compiler.js:81:7)
      at Watching.<anonymous> (C:\source\ts-loader\node_modules\webpack\lib\Compiler.js:61:18)
      at Compiler.emitRecords (C:\source\ts-loader\node_modules\webpack\lib\Compiler.js:282:37)
      at Watching.<anonymous> (C:\source\ts-loader\node_modules\webpack\lib\Compiler.js:58:19)
      at C:\source\ts-loader\node_modules\webpack\lib\Compiler.js:275:11
      at Compiler.applyPluginsAsync (C:\source\ts-loader\node_modules\tapable\lib\Tapable.js:60:69)
      at Compiler.afterEmit (C:\source\ts-loader\node_modules\webpack\lib\Compiler.js:272:8)
      at Compiler.<anonymous> (C:\source\ts-loader\node_modules\webpack\lib\Compiler.js:267:14)
      at C:\source\ts-loader\node_modules\async\lib\async.js:52:16
      at done (C:\source\ts-loader\node_modules\async\lib\async.js:246:17)
      at C:\source\ts-loader\node_modules\async\lib\async.js:44:16
      at C:\source\ts-loader\node_modules\graceful-fs\graceful-fs.js:42:10
      at C:\Source\ts-loader\node_modules\mocha\node_modules\graceful-fs\graceful-fs.js:104:5
      at FSReqWrap.oncomplete (fs.js:82:15)

  2) issue81 should work with transpile:

      Uncaught AssertionError: output.txt is different between actual and expected
      + expected - actual

               Asset     Size  Chunks             Chunk Names
           bundle.js  2.42 kB       0  [emitted]  main
      -bundle.js.map  2.54 kB       0  [emitted]  main
      +bundle.js.map  2.53 kB       0  [emitted]  main
       chunk    {0} bundle.js, bundle.js.map (main) 896 bytes [rendered]
           [0] ./.test/issue81/a.ts 896 bytes {0} [built]

      at C:\source\ts-loader\test\run.js:243:28
      at Array.forEach (native)
      at Watching.handler (C:\source\ts-loader\test\run.js:239:39)
      at Watching._done (C:\source\ts-loader\node_modules\webpack\lib\Compiler.js:81:7)
      at Watching.<anonymous> (C:\source\ts-loader\node_modules\webpack\lib\Compiler.js:61:18)
      at Compiler.emitRecords (C:\source\ts-loader\node_modules\webpack\lib\Compiler.js:282:37)
      at Watching.<anonymous> (C:\source\ts-loader\node_modules\webpack\lib\Compiler.js:58:19)
      at C:\source\ts-loader\node_modules\webpack\lib\Compiler.js:275:11
      at Compiler.applyPluginsAsync (C:\source\ts-loader\node_modules\tapable\lib\Tapable.js:60:69)
      at Compiler.afterEmit (C:\source\ts-loader\node_modules\webpack\lib\Compiler.js:272:8)
      at Compiler.<anonymous> (C:\source\ts-loader\node_modules\webpack\lib\Compiler.js:267:14)
      at C:\source\ts-loader\node_modules\async\lib\async.js:52:16
      at done (C:\source\ts-loader\node_modules\async\lib\async.js:246:17)
      at C:\source\ts-loader\node_modules\async\lib\async.js:44:16
      at C:\source\ts-loader\node_modules\graceful-fs\graceful-fs.js:42:10
      at C:\Source\ts-loader\node_modules\mocha\node_modules\graceful-fs\graceful-fs.js:104:5
      at FSReqWrap.oncomplete (fs.js:82:15)



```
Spot it?

The windows carriage returns have actually marginally changed **file size** (from 2.53 kB to 2.54 kB) and it's showing up in the output.txt.  I'm not sure what the best way to handle this is.  What do you think?