### PR TITLE
Don't force module output when targeting ES6

### DIFF
--- a/test/es6withCJS/app.ts
+++ b/test/es6withCJS/app.ts
@@ -1,0 +1,1 @@
+export default 'a';

--- a/test/es6withCJS/expectedOutput-1.6/output.txt
+++ b/test/es6withCJS/expectedOutput-1.6/output.txt
@@ -1,0 +1,6 @@
+
+ERROR in ./.test/es6withCJS/app.ts
+Module parse failed: index.js!app.ts Line 1: Unexpected token
+You may need an appropriate loader to handle this file type.
+| export default 'a';
+| 

--- a/test/es6withCJS/expectedOutput-1.7/bundle.js
+++ b/test/es6withCJS/expectedOutput-1.7/bundle.js
@@ -1,0 +1,51 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	exports.default = 'a';
+
+
+/***/ }
+/******/ ]);

--- a/test/es6withCJS/expectedOutput-1.7/output.txt
+++ b/test/es6withCJS/expectedOutput-1.7/output.txt
@@ -1,0 +1,4 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.41 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 23 bytes [rendered]
+    [0] ./.test/es6withCJS/app.ts 23 bytes {0} [built]

--- a/test/es6withCJS/expectedOutput-1.8/bundle.js
+++ b/test/es6withCJS/expectedOutput-1.8/bundle.js
@@ -1,0 +1,53 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	"use strict";
+	Object.defineProperty(exports, "__esModule", { value: true });
+	exports.default = 'a';
+
+
+/***/ }
+/******/ ]);

--- a/test/es6withCJS/expectedOutput-1.8/output.txt
+++ b/test/es6withCJS/expectedOutput-1.8/output.txt
@@ -1,0 +1,4 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.49 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 100 bytes [rendered]
+    [0] ./.test/es6withCJS/app.ts 100 bytes {0} [built]

--- a/test/es6withCJS/tsconfig.json
+++ b/test/es6withCJS/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "module": "commonjs"
+    }
+}

--- a/test/es6withCJS/webpack.config.js
+++ b/test/es6withCJS/webpack.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+    entry: './app.ts',
+    output: {
+        filename: 'bundle.js'
+    },
+    resolve: {
+        extensions: ['', '.ts', '.js']
+    },
+    module: {
+        loaders: [
+            { test: /\.ts$/, loader: 'ts-loader' }
+        ]
+    }
+}
+
+// for test harness purposes only, you would not need this in a normal project
+module.exports.resolveLoader = { alias: { 'ts-loader': require('path').join(__dirname, "../../index.js") } }

--- a/test/ignoreDiagnostics/expectedOutput-1.8/output.txt
+++ b/test/ignoreDiagnostics/expectedOutput-1.8/output.txt
@@ -4,5 +4,4 @@ chunk    {0} bundle.js (main) 247 bytes [rendered]
     [0] ./.test/ignoreDiagnostics/app.ts 247 bytes {0} [built] [1 error]
 
 ERROR in ./.test/ignoreDiagnostics/app.ts
-[37m([39m[36m9[39m,[36m5[39m): [31merror TS2322: Type 'string' is not assignable to type 'Number'.
-  Property 'toFixed' is missing in type 'String'.[39m
+[37m([39m[36m9[39m,[36m5[39m): [31merror TS2322: Type 'string' is not assignable to type 'Number'.[39m


### PR DESCRIPTION
This PR cleans up module defaults and target handling and fixes #111 and #132

Previously the module output was defaulted to CommonJS except in the case where the target was set to ES6, in which case the module output was forced to "None". This worked well in TS 1.6 but causes problems in TS 1.7+ because it's impossible to configure ts-loader to `target: es6` and `module: commonjs`.

The new behavior is as follows:

- Default to CommonJS ONLY if `target` is **NOT** `es6`. This is a breaking change, but causes ts-loader to behave a little more like `tsc` (in that if you specify a `target: es6` but not module the output is es6 modules) and also will eventually provide a better default experience when webpack2 hits.
- If using TS 1.6, revert to the old behavior of forcing `module: none` if `target: es6`

Additionally this PR cleans up default lib handling (#67) and fixes a test based on a change in the nightly.