### PR TITLE
Fix support for `npm link`ing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
-    "test": "mocha --reporter spec test/run.js",
+    "test": "npm link ./test/testLib && mocha --reporter spec test/run.js",
     "prepublish": "npm run build"
   },
   "repository": {

--- a/test/npmLink/app.ts
+++ b/test/npmLink/app.ts
@@ -1,0 +1,3 @@
+import lib from 'lib/foo';
+
+console.log(lib);

--- a/test/npmLink/expectedOutput-1.6/bundle.js
+++ b/test/npmLink/expectedOutput-1.6/bundle.js
@@ -1,0 +1,60 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var foo_1 = __webpack_require__(1);
+	console.log(foo_1["default"]);
+
+
+/***/ },
+/* 1 */
+/***/ function(module, exports) {
+
+	exports.__esModule = true;
+	exports["default"] = 'foo';
+
+
+/***/ }
+/******/ ]);

--- a/test/npmLink/expectedOutput-1.6/output.txt
+++ b/test/npmLink/expectedOutput-1.6/output.txt
@@ -1,0 +1,5 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.59 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 118 bytes [rendered]
+    [0] ./.test/npmLink/app.ts 63 bytes {0} [built]
+    [1] ./test/testLib/foo.ts 55 bytes {0} [built]

--- a/test/npmLink/expectedOutput-1.7/bundle.js
+++ b/test/npmLink/expectedOutput-1.7/bundle.js
@@ -1,0 +1,60 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var foo_1 = __webpack_require__(1);
+	console.log(foo_1["default"]);
+
+
+/***/ },
+/* 1 */
+/***/ function(module, exports) {
+
+	exports.__esModule = true;
+	exports["default"] = 'foo';
+
+
+/***/ }
+/******/ ]);

--- a/test/npmLink/expectedOutput-1.7/output.txt
+++ b/test/npmLink/expectedOutput-1.7/output.txt
@@ -1,0 +1,5 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.59 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 118 bytes [rendered]
+    [0] ./.test/npmLink/app.ts 63 bytes {0} [built]
+    [1] ./test/testLib/foo.ts 55 bytes {0} [built]

--- a/test/npmLink/expectedOutput-1.8/bundle.js
+++ b/test/npmLink/expectedOutput-1.8/bundle.js
@@ -1,0 +1,62 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	var foo_1 = __webpack_require__(1);
+	console.log(foo_1["default"]);
+
+
+/***/ },
+/* 1 */
+/***/ function(module, exports) {
+
+	"use strict";
+	exports.__esModule = true;
+	exports["default"] = 'foo';
+
+
+/***/ }
+/******/ ]);

--- a/test/npmLink/expectedOutput-1.8/output.txt
+++ b/test/npmLink/expectedOutput-1.8/output.txt
@@ -1,0 +1,5 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.62 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 146 bytes [rendered]
+    [0] ./.test/npmLink/app.ts 77 bytes {0} [built]
+    [1] ./test/testLib/foo.ts 69 bytes {0} [built]

--- a/test/npmLink/tsconfig.json
+++ b/test/npmLink/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"compilerOptions": {
+		"module": "commonjs"
+	},
+	"files": []
+}

--- a/test/npmLink/webpack.config.js
+++ b/test/npmLink/webpack.config.js
@@ -1,0 +1,19 @@
+var path = require('path')
+
+module.exports = {
+    entry: './app.ts',
+    output: {
+        filename: 'bundle.js'
+    },
+    resolve: {
+        extensions: ['', '.ts', '.js']
+    },
+    module: {
+        loaders: [
+            { test: /\.ts$/, loader: 'ts-loader' }
+        ]
+    }
+}
+
+// for test harness purposes only, you would not need this in a normal project
+module.exports.resolveLoader = { alias: { 'ts-loader': require('path').join(__dirname, "../../index.js") } }

--- a/test/run.js
+++ b/test/run.js
@@ -33,6 +33,8 @@ fs.readdirSync(__dirname).forEach(function(test) {
     var testPath = path.join(__dirname, test);
     if (fs.statSync(testPath).isDirectory()) {
         
+        if (test == 'testLib') return;
+        
         if (test == 'issue81' && semver.lt(typescript.version, '1.7.0-0')) return;
         
         describe(test, function() {

--- a/test/testLib/foo.ts
+++ b/test/testLib/foo.ts
@@ -1,0 +1,1 @@
+export default 'foo';

--- a/test/testLib/package.json
+++ b/test/testLib/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lib",
+  "version": "0.0.1",
+  "description": "Dummy lib for npm link testing for ts-loader"
+}


### PR DESCRIPTION
This fixes #134 by no longer using `getScriptSnapshot` in the ModuleResolutionHost. The issue with `getScriptSnapshot` is that it adds found files to the program cache which can cause discrepancies between the real path of the module and the symlink (webpack returns the real path, typescript finds and returns the symlink).