### PR TITLE
Feature/108 exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ messages are emitted via webpack which is not affected by this flag.
 ##### ignoreDiagnostics *(number[]) (default=[])*
 
 You can squelch certain TypeScript errors by specifying an array of diagnostic
-codes to ignore. 
+codes to ignore.
 
 ##### compiler *(string) (default='typescript')*
 
@@ -169,6 +169,23 @@ require('!style!css!./style.css');
 The same basic process is required for code splitting. In this case, you `import` modules you need but you
 don't directly use them. Instead you require them at [split points](http://webpack.github.io/docs/code-splitting.html#defining-a-split-point).
 See [this example](test/codeSplitting) for more details.
+
+## Failing CI builds on errors
+
+`webpack` command should return non-zero exit code in order to fail build when errors occur. To achieve this add the following plugin (*addMe* function) to `plugins` field of webpack config object:
+```
+{
+    plugins: [
+        function addMe() {
+            this.plugin("done", function(stats) {
+                if (stats.compilation.errors && stats.compilation.errors.length && process.argv.indexOf('--watch') == -1) {
+                    process.exit(1);
+                }
+            });
+        }
+    ]
+}
+```
 
 ## Contributing
 


### PR DESCRIPTION
This provides a workaround for #108. The issue is very simple to reproduce:
1. Add some mess to TypeScript code to get compilation error(s).
2. Run `webpack` with ts-loader
3. Check exit code. It is 0. 

That's a major problem, because build server executing such build will report success when there are errors in TypeScript code.

Workaround is simple and consists of 2 steps:
1. Add plugin that executes on `done` and exits process with non-zero exit code if error(s) present
2. Add logging to ts-loader in order to provide detailed info on compilation error(s)

The solution works fine on my project. 