### PR TITLE
Make invalid files in tsconfig.json super obvious when ts-loader errors

### DIFF
--- a/test/tsconfigInvalidFile/expectedOutput-1.6/bundle.transpiled.js
+++ b/test/tsconfigInvalidFile/expectedOutput-1.6/bundle.transpiled.js
@@ -1,0 +1,50 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	
+
+/***/ }
+/******/ ]);

--- a/test/tsconfigInvalidFile/expectedOutput-1.6/output.transpiled.txt
+++ b/test/tsconfigInvalidFile/expectedOutput-1.6/output.transpiled.txt
@@ -1,0 +1,4 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.39 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 0 bytes [rendered]
+    [0] ./.test/tsconfigInvalidFile/app.ts 0 bytes {0} [built]

--- a/test/tsconfigInvalidFile/expectedOutput-1.6/output.txt
+++ b/test/tsconfigInvalidFile/expectedOutput-1.6/output.txt
@@ -1,0 +1,3 @@
+
+ERROR in ./.test/tsconfigInvalidFile/app.ts
+Module build failed: [31mA file specified in tsconfig.json could not be found: i-am-a-file-what-does-not-exist.ts[39m

--- a/test/tsconfigInvalidFile/expectedOutput-1.7/bundle.transpiled.js
+++ b/test/tsconfigInvalidFile/expectedOutput-1.7/bundle.transpiled.js
@@ -1,0 +1,50 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	
+
+/***/ }
+/******/ ]);

--- a/test/tsconfigInvalidFile/expectedOutput-1.7/output.transpiled.txt
+++ b/test/tsconfigInvalidFile/expectedOutput-1.7/output.transpiled.txt
@@ -1,0 +1,4 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.39 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 0 bytes [rendered]
+    [0] ./.test/tsconfigInvalidFile/app.ts 0 bytes {0} [built]

--- a/test/tsconfigInvalidFile/expectedOutput-1.7/output.txt
+++ b/test/tsconfigInvalidFile/expectedOutput-1.7/output.txt
@@ -1,0 +1,3 @@
+
+ERROR in ./.test/tsconfigInvalidFile/app.ts
+Module build failed: [31mA file specified in tsconfig.json could not be found: i-am-a-file-what-does-not-exist.ts[39m

--- a/test/tsconfigInvalidFile/expectedOutput-1.8/bundle.transpiled.js
+++ b/test/tsconfigInvalidFile/expectedOutput-1.8/bundle.transpiled.js
@@ -1,0 +1,50 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	
+
+/***/ }
+/******/ ]);

--- a/test/tsconfigInvalidFile/expectedOutput-1.8/bundle.transpiled.js
+++ b/test/tsconfigInvalidFile/expectedOutput-1.8/bundle.transpiled.js
@@ -44,7 +44,8 @@
 /* 0 */
 /***/ function(module, exports) {
 
-	
+	"use strict";
+
 
 /***/ }
 /******/ ]);

--- a/test/tsconfigInvalidFile/expectedOutput-1.8/output.transpiled.txt
+++ b/test/tsconfigInvalidFile/expectedOutput-1.8/output.transpiled.txt
@@ -1,4 +1,4 @@
-    Asset     Size  Chunks             Chunk Names
-bundle.js  1.39 kB       0  [emitted]  main
-chunk    {0} bundle.js (main) 0 bytes [rendered]
-    [0] ./.test/tsconfigInvalidFile/app.ts 0 bytes {0} [built]
+    Asset    Size  Chunks             Chunk Names
+bundle.js  1.4 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 14 bytes [rendered]
+    [0] ./.test/tsconfigInvalidFile/app.ts 14 bytes {0} [built]

--- a/test/tsconfigInvalidFile/expectedOutput-1.8/output.transpiled.txt
+++ b/test/tsconfigInvalidFile/expectedOutput-1.8/output.transpiled.txt
@@ -1,0 +1,4 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.39 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 0 bytes [rendered]
+    [0] ./.test/tsconfigInvalidFile/app.ts 0 bytes {0} [built]

--- a/test/tsconfigInvalidFile/expectedOutput-1.8/output.txt
+++ b/test/tsconfigInvalidFile/expectedOutput-1.8/output.txt
@@ -1,0 +1,3 @@
+
+ERROR in ./.test/tsconfigInvalidFile/app.ts
+Module build failed: [31mA file specified in tsconfig.json could not be found: i-am-a-file-what-does-not-exist.ts[39m

--- a/test/tsconfigInvalidFile/tsconfig.json
+++ b/test/tsconfigInvalidFile/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"compilerOptions": {
+			"sourceMap": true
+	},
+	"files": [
+        "i-am-a-file-what-does-not-exist.ts",
+        "app.ts"
+    ]
+}

--- a/test/tsconfigInvalidFile/webpack.config.js
+++ b/test/tsconfigInvalidFile/webpack.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+    entry: './app.ts',
+    output: {
+        filename: 'bundle.js'
+    },
+    resolve: {
+        extensions: ['', '.ts', '.js']
+    },
+    module: {
+        loaders: [
+            { test: /\.ts$/, loader: 'ts-loader' }
+        ]
+    }
+}
+
+// for test harness purposes only, you would not need this in a normal project
+module.exports.resolveLoader = { alias: { 'ts-loader': require('path').join(__dirname, "../../index.js") } }


### PR DESCRIPTION
Hey @jbrantly 

This PR is to mitigate the problems of https://github.com/TypeStrong/ts-loader/issues/117 - invalid files in `tsconfig.json` will be very obvious as a result of the change to error message.  Hope you like it; happy to tweak further.  I've added a test as well.