### PR TITLE
fix for typescript 1.8.0

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -520,7 +520,9 @@ function loader(contents) {
         compiler: 'typescript',
         configFileName: 'tsconfig.json',
         transpileOnly: false,
-        compilerOptions: {}
+        compilerOptions: {
+             noEmit: false
+        }
     }, configFileOptions, queryOptions);
     options.ignoreDiagnostics = arrify(options.ignoreDiagnostics).map(Number);
 


### PR DESCRIPTION
if noEmit === true in tsconfig.json typescript emmits no output. it actual since 1.8
see my [comment](https://github.com/TypeStrong/ts-loader/issues/147#issuecomment-180095768)