### PR TITLE
Implement new option instancePerProject

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -28,6 +28,7 @@ function hasOwnProperty(obj, property) {
 interface LoaderOptions {
     silent: boolean;
     instance: string;
+    instancePerProject: boolean;
     compiler: string;
     configFileName: string;
     transpileOnly: boolean;
@@ -523,6 +524,12 @@ function loader(contents) {
         compilerOptions: {}
     }, configFileOptions, queryOptions);
     options.ignoreDiagnostics = arrify(options.ignoreDiagnostics).map(Number);
+
+    // if instancePerProject is set, and instance has not been set, find the
+    // path of the tsconfig.json file and use it as the instance
+    if (options.instancePerProject && options.instance === 'default') {
+        options.instance = findConfigFile(require(options.compiler), path.dirname(filePath), options.configFileName);
+    }
 
     // differentiate the TypeScript instance based on the webpack instance
     var webpackIndex = webpackInstances.indexOf(this._compiler);


### PR DESCRIPTION
I have a project with references to node modules containing only pure typescript files and a `tsconfig.json` file in each node module. When I run webpack ts-loader fails to resolve typings (*.d.ts files) in these node modules.
It seems that this is because the `tsconfig.json` file in the main project is used.
To solve this, I have introduced a new option: `instancePerProject`.
If `instancePerProject` is `true` _and_ `instance` has not been set (ie. `instance` === 'default') the instance is set to the path of `tsconfig.json` (actually option `configFileName`) for each file to be compiled.
