### PR TITLE
Declarations update independent of compiler.watchFileSystem

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -488,7 +488,8 @@ function ensureTypeScriptInstance(loaderOptions: LoaderOptions, loader: any): { 
 
     // manually update changed declaration files
     loader._compiler.plugin("watch-run", (watching, cb) => {
-        var mtimes = watching.compiler.watchFileSystem.watcher.mtimes;
+        var mtimes = watching.compiler.fileTimestamps ||
+                     watching.compiler.watchFileSystem.watcher.mtimes;
         Object.keys(mtimes)
             .filter(filePath => !!filePath.match(/\.d\.ts$/))
             .forEach(filePath => {


### PR DESCRIPTION
Uses watching.compiler.fileTimestamps which is set directly in
the compiler. See https://github.com/webpack/webpack/blob/master/lib/Compiler.js#L105.

Fixes the https://github.com/TypeStrong/ts-loader/issues/155
when using the webpack.OldNodeWatchFileSystem.