### PR TITLE
Change compiler Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ module.exports = {
   module: {
     loaders: [
       // specify option using query
-      { test: /\.tsx?$/, loader: 'ts-loader?compiler=ntypescript' }
+      { test: /\.tsx?$/, loader: 'ts-loader?compiler=typescript' }
     ]
   },
   // specify option using `ts` property
   ts: {
-    compiler: 'ntypescript'
+    compiler: 'typescript'
   }
 }
 ```


### PR DESCRIPTION
I don't know if it is just a typo, but in my case a had to change the name of the ts compiler from `ntypescript` to `typescript`, as webpack threw an error stating that `ntypescript` package was not found.
Feel free to close this PR if my changes do not make any sense at all ;)