### PR TITLE
update html-webpack-plugin to latest version to fix 2 tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "escape-string-regexp": "^1.0.3",
     "fs-extra": "^0.22.1",
     "glob": "^6.0.3",
-    "html-webpack-plugin": "^2.8.1",
+    "html-webpack-plugin": "^2.16.1",
     "mkdirp": "^0.5.1",
     "mocha": "^2.1.0",
     "rimraf": "^2.4.2",

--- a/test/html-webpack-plugin/expectedOutput-1.6/output.txt
+++ b/test/html-webpack-plugin/expectedOutput-1.6/output.txt
@@ -5,8 +5,8 @@ chunk    {0} bundle.js (main) 22 bytes [rendered]
     [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
 Child html-webpack-plugin for "index.html":
          Asset    Size  Chunks       Chunk Names
-    index.html  519 kB       0       
-    chunk    {0} index.html 502 kB [rendered]
+    index.html  529 kB       0       
+    chunk    {0} index.html 512 kB [rendered]
         [0] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 550 bytes {0} [built]
-        [1] ./~/html-webpack-plugin/~/lodash/lodash.js 502 kB {0} [built]
+        [1] ./~/html-webpack-plugin/~/lodash/lodash.js 511 kB {0} [built]
         [2] (webpack)/buildin/module.js 241 bytes {0} [built]

--- a/test/html-webpack-plugin/expectedOutput-1.7/output.txt
+++ b/test/html-webpack-plugin/expectedOutput-1.7/output.txt
@@ -5,8 +5,8 @@ chunk    {0} bundle.js (main) 22 bytes [rendered]
     [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
 Child html-webpack-plugin for "index.html":
          Asset    Size  Chunks       Chunk Names
-    index.html  519 kB       0       
-    chunk    {0} index.html 502 kB [rendered]
+    index.html  529 kB       0       
+    chunk    {0} index.html 512 kB [rendered]
         [0] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 550 bytes {0} [built]
-        [1] ./~/html-webpack-plugin/~/lodash/lodash.js 502 kB {0} [built]
+        [1] ./~/html-webpack-plugin/~/lodash/lodash.js 511 kB {0} [built]
         [2] (webpack)/buildin/module.js 241 bytes {0} [built]

--- a/test/html-webpack-plugin/expectedOutput-1.8/output.transpiled.txt
+++ b/test/html-webpack-plugin/expectedOutput-1.8/output.transpiled.txt
@@ -5,8 +5,8 @@ chunk    {0} bundle.js (main) 36 bytes [rendered]
     [0] ./.test/html-webpack-plugin/app.ts 36 bytes {0} [built]
 Child html-webpack-plugin for "index.html":
          Asset    Size  Chunks       Chunk Names
-    index.html  519 kB       0       
-    chunk    {0} index.html 502 kB [rendered]
+    index.html  529 kB       0       
+    chunk    {0} index.html 512 kB [rendered]
         [0] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 550 bytes {0} [built]
-        [1] ./~/html-webpack-plugin/~/lodash/lodash.js 502 kB {0} [built]
+        [1] ./~/html-webpack-plugin/~/lodash/lodash.js 511 kB {0} [built]
         [2] (webpack)/buildin/module.js 241 bytes {0} [built]

--- a/test/html-webpack-plugin/expectedOutput-1.8/output.txt
+++ b/test/html-webpack-plugin/expectedOutput-1.8/output.txt
@@ -5,8 +5,8 @@ chunk    {0} bundle.js (main) 22 bytes [rendered]
     [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
 Child html-webpack-plugin for "index.html":
          Asset    Size  Chunks       Chunk Names
-    index.html  519 kB       0       
-    chunk    {0} index.html 502 kB [rendered]
+    index.html  529 kB       0       
+    chunk    {0} index.html 512 kB [rendered]
         [0] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 550 bytes {0} [built]
-        [1] ./~/html-webpack-plugin/~/lodash/lodash.js 502 kB {0} [built]
+        [1] ./~/html-webpack-plugin/~/lodash/lodash.js 511 kB {0} [built]
         [2] (webpack)/buildin/module.js 241 bytes {0} [built]

--- a/test/html-webpack-plugin/expectedOutput-1.9/output.transpiled.txt
+++ b/test/html-webpack-plugin/expectedOutput-1.9/output.transpiled.txt
@@ -5,8 +5,8 @@ chunk    {0} bundle.js (main) 36 bytes [rendered]
     [0] ./.test/html-webpack-plugin/app.ts 36 bytes {0} [built]
 Child html-webpack-plugin for "index.html":
          Asset    Size  Chunks       Chunk Names
-    index.html  426 kB       0       
-    chunk    {0} index.html 412 kB [rendered]
-        [0] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 356 bytes {0} [built]
-        [1] ./~/html-webpack-plugin/~/lodash/index.js 411 kB {0} [built]
+    index.html  529 kB       0       
+    chunk    {0} index.html 512 kB [rendered]
+        [0] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 550 bytes {0} [built]
+        [1] ./~/html-webpack-plugin/~/lodash/lodash.js 511 kB {0} [built]
         [2] (webpack)/buildin/module.js 241 bytes {0} [built]

--- a/test/html-webpack-plugin/expectedOutput-1.9/output.txt
+++ b/test/html-webpack-plugin/expectedOutput-1.9/output.txt
@@ -5,8 +5,8 @@ chunk    {0} bundle.js (main) 22 bytes [rendered]
     [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
 Child html-webpack-plugin for "index.html":
          Asset    Size  Chunks       Chunk Names
-    index.html  426 kB       0       
-    chunk    {0} index.html 412 kB [rendered]
-        [0] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 356 bytes {0} [built]
-        [1] ./~/html-webpack-plugin/~/lodash/index.js 411 kB {0} [built]
+    index.html  529 kB       0       
+    chunk    {0} index.html 512 kB [rendered]
+        [0] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 550 bytes {0} [built]
+        [1] ./~/html-webpack-plugin/~/lodash/lodash.js 511 kB {0} [built]
         [2] (webpack)/buildin/module.js 241 bytes {0} [built]


### PR DESCRIPTION
Also udated associated test results to reflect incremented lodash version.  This should fix 2 of the webpack tests that have been failing for a while.  The ^ meant that the version used was always the latest and when it changed the tests broke.  This will likely happen again at some point by the way; but I guess that's intentional?