### PR TITLE
Fix some html-weback-plugin tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "escape-string-regexp": "^1.0.3",
     "fs-extra": "^0.22.1",
     "glob": "^6.0.3",
-    "html-webpack-plugin": "^2.16.1",
+    "html-webpack-plugin": "^2.17.0",
     "mkdirp": "^0.5.1",
     "mocha": "^2.1.0",
     "rimraf": "^2.4.2",

--- a/test/html-webpack-plugin/expectedOutput-1.6/index.html
+++ b/test/html-webpack-plugin/expectedOutput-1.6/index.html
@@ -5,5 +5,5 @@
     <title>Webpack App</title>
   </head>
   <body>
-  <script src="bundle.js"></script></body>
+  <script type="text/javascript" src="bundle.js"></script></body>
 </html>

--- a/test/html-webpack-plugin/expectedOutput-1.6/output.txt
+++ b/test/html-webpack-plugin/expectedOutput-1.6/output.txt
@@ -1,6 +1,6 @@
      Asset       Size  Chunks             Chunk Names
  bundle.js    1.41 kB       0  [emitted]  main
-index.html  159 bytes          [emitted]  
+index.html  182 bytes          [emitted]  
 chunk    {0} bundle.js (main) 22 bytes [rendered]
     [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
 Child html-webpack-plugin for "index.html":

--- a/test/html-webpack-plugin/expectedOutput-1.7/index.html
+++ b/test/html-webpack-plugin/expectedOutput-1.7/index.html
@@ -5,5 +5,5 @@
     <title>Webpack App</title>
   </head>
   <body>
-  <script src="bundle.js"></script></body>
+  <script type="text/javascript" src="bundle.js"></script></body>
 </html>

--- a/test/html-webpack-plugin/expectedOutput-1.7/output.txt
+++ b/test/html-webpack-plugin/expectedOutput-1.7/output.txt
@@ -1,6 +1,6 @@
      Asset       Size  Chunks             Chunk Names
  bundle.js    1.41 kB       0  [emitted]  main
-index.html  159 bytes          [emitted]  
+index.html  182 bytes          [emitted]  
 chunk    {0} bundle.js (main) 22 bytes [rendered]
     [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
 Child html-webpack-plugin for "index.html":

--- a/test/html-webpack-plugin/expectedOutput-1.8/index.html
+++ b/test/html-webpack-plugin/expectedOutput-1.8/index.html
@@ -5,5 +5,5 @@
     <title>Webpack App</title>
   </head>
   <body>
-  <script src="bundle.js"></script></body>
+  <script type="text/javascript" src="bundle.js"></script></body>
 </html>

--- a/test/html-webpack-plugin/expectedOutput-1.8/output.transpiled.txt
+++ b/test/html-webpack-plugin/expectedOutput-1.8/output.transpiled.txt
@@ -1,6 +1,6 @@
      Asset       Size  Chunks             Chunk Names
  bundle.js    1.43 kB       0  [emitted]  main
-index.html  159 bytes          [emitted]  
+index.html  182 bytes          [emitted]  
 chunk    {0} bundle.js (main) 36 bytes [rendered]
     [0] ./.test/html-webpack-plugin/app.ts 36 bytes {0} [built]
 Child html-webpack-plugin for "index.html":

--- a/test/html-webpack-plugin/expectedOutput-1.8/output.txt
+++ b/test/html-webpack-plugin/expectedOutput-1.8/output.txt
@@ -1,6 +1,6 @@
      Asset       Size  Chunks             Chunk Names
  bundle.js    1.41 kB       0  [emitted]  main
-index.html  159 bytes          [emitted]  
+index.html  182 bytes          [emitted]  
 chunk    {0} bundle.js (main) 22 bytes [rendered]
     [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
 Child html-webpack-plugin for "index.html":

--- a/test/html-webpack-plugin/expectedOutput-1.9/index.html
+++ b/test/html-webpack-plugin/expectedOutput-1.9/index.html
@@ -5,5 +5,5 @@
     <title>Webpack App</title>
   </head>
   <body>
-  <script src="bundle.js"></script></body>
+  <script type="text/javascript" src="bundle.js"></script></body>
 </html>

--- a/test/html-webpack-plugin/expectedOutput-1.9/output.transpiled.txt
+++ b/test/html-webpack-plugin/expectedOutput-1.9/output.transpiled.txt
@@ -1,6 +1,6 @@
      Asset       Size  Chunks             Chunk Names
  bundle.js    1.43 kB       0  [emitted]  main
-index.html  159 bytes          [emitted]  
+index.html  182 bytes          [emitted]  
 chunk    {0} bundle.js (main) 36 bytes [rendered]
     [0] ./.test/html-webpack-plugin/app.ts 36 bytes {0} [built]
 Child html-webpack-plugin for "index.html":

--- a/test/html-webpack-plugin/expectedOutput-1.9/output.txt
+++ b/test/html-webpack-plugin/expectedOutput-1.9/output.txt
@@ -1,6 +1,6 @@
      Asset       Size  Chunks             Chunk Names
  bundle.js    1.41 kB       0  [emitted]  main
-index.html  159 bytes          [emitted]  
+index.html  182 bytes          [emitted]  
 chunk    {0} bundle.js (main) 22 bytes [rendered]
     [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
 Child html-webpack-plugin for "index.html":


### PR DESCRIPTION
they now require `type="text/javascript" ` in the output...