### PR TITLE
Make ts-loader compatible with node v6

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -250,13 +250,13 @@ function ensureTypeScriptInstance(loaderOptions: LoaderOptions, loader: any): { 
         configParseResult = (<TSCompatibleCompiler><any>compiler).parseJsonConfigFileContent(
             configFile.config,
             compiler.sys,
-            path.dirname(configFilePath)
+            path.dirname(configFilePath || '')
         );
     } else {
         configParseResult = (<TSCompatibleCompiler><any>compiler).parseConfigFile(
             configFile.config,
             compiler.sys,
-            path.dirname(configFilePath)
+            path.dirname(configFilePath || '')
         );
     }
 


### PR DESCRIPTION
Node 6+ enforces the parameter to path.dirname to be a string (https://github.com/nodejs/node/commit/08085c49b6e49ecfffd638c6cd46f4de639ae4f4). The empty string results in the previous behavior.