### PR TITLE
Use a relative path for the declaration assets

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -496,7 +496,8 @@ function ensureTypeScriptInstance(loaderOptions: LoaderOptions, loader: any): { 
                 let output = languageService.getEmitOutput(filePath);
                 let declarationFile = output.outputFiles.filter(filePath => !!filePath.name.match(/\.d.ts$/)).pop();
                 if (declarationFile) {
-                    compilation.assets[declarationFile.name] = {
+                    let assetPath = path.relative(process.cwd(), declarationFile.name);
+                    compilation.assets[assetPath] = {
                         source: () => declarationFile.text,
                         size: () => declarationFile.text.length
                     };


### PR DESCRIPTION
This is intended as a fix for issue #185 - a full explanation of what the problem was can be found in [this comment](https://github.com/TypeStrong/ts-loader/issues/185#issuecomment-222118959), but what it boiled down to is that the language service returns absolute paths for generated declaration files, and these were being used directly as keys in `compilation.assets`, causing Webpack to hang during the emit stage. Resolving the path relative to the current working directory beforehand fixes this issue. According to @t246246's comment on the issue, this only affects Windows, but as I don't have access to a Linux or OSX device, I can't confirm that.

One caveat to this fix is that the output file structure for the declaration files follows that of the source code - i.e, if the source looks like this:

```
root/
    src/
        dir1/
        dir2/
```

Then the declarations get output like so:

```
root/
    dist/
        src/
            dir1/
            dir2/
    src/
        dir1/
        dir2/
```

This might well be a breaking change or not be the 'correct' way of handling it - I can't tell, as this functionality never worked for me in the first place! There's a [currently pending pull request](https://github.com/s-panferov/awesome-typescript-loader/pull/136) on awesome-typescript-loader's repository that demonstrates a possible way of making it follow Webpack's context instead - if the current way files are output isn't acceptable, I can have a go at implementing something along those lines here instead? Let me know, I can make some more changes if needed. This should be a good start though, at the very least.