### PR TITLE
Enable loader to exclude files matching regex for error checks

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -471,8 +471,7 @@ function ensureTypeScriptInstance(loaderOptions: LoaderOptions, loader: any): { 
               if (!!filePath.match(loaderOptions.excludeErrorCheck)) { return false; }
             } else if (loaderOptions.excludeErrorCheck.constructor === Array) {
               // Filter if matches any of the regexps
-              for (var i = 0; i < loaderOptions.excludeErrorCheck.length; i++) {
-                var excludeRegexp = loaderOptions.excludeErrorCheck[i];
+              for (let excludeRegExp of loaderOptions.excludeErrorCheck) {
                 if (!!filePath.match(excludeRegexp)) { return false; }
               }
             }

--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ interface LoaderOptions {
     compiler: string;
     configFileName: string;
     transpileOnly: boolean;
+    excludeErrorCheck: RegExp | Array<RegExp>;
     ignoreDiagnostics: number[];
     compilerOptions: typescript.CompilerOptions;
 }
@@ -462,7 +463,7 @@ function ensureTypeScriptInstance(loaderOptions: LoaderOptions, loader: any): { 
             }
         })
 
-        let tsRegex = new RegExp(/(\.d)?\.ts(x?)$/);
+        let tsRegex: RegExp = /(\.d)?\.ts(x?)$/;
         function filterFiles(filePath) {
           // Filters files we don't want to catch errors from TypeScript
           if (loaderOptions.excludeErrorCheck) {
@@ -471,7 +472,7 @@ function ensureTypeScriptInstance(loaderOptions: LoaderOptions, loader: any): { 
               if (!!filePath.match(loaderOptions.excludeErrorCheck)) { return false; }
             } else if (loaderOptions.excludeErrorCheck.constructor === Array) {
               // Filter if matches any of the regexps
-              for (let excludeRegExp of loaderOptions.excludeErrorCheck) {
+              for (let excludeRegexp of (loaderOptions.excludeErrorCheck as Array<RegExp>)) {
                 if (!!filePath.match(excludeRegexp)) { return false; }
               }
             }


### PR DESCRIPTION
Error checks are a huge bottleneck to the ts-loader.  Refer to #255 