### PR TITLE
Normalize dependency graph paths - Fix broken dependencies on Windows

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -398,7 +398,7 @@ function ensureTypeScriptInstance(loaderOptions: LoaderOptions, loader: any): { 
                 resolvedModules.push(resolutionResult);
             }
             
-            instance.dependencyGraph[containingFile] = resolvedModules.filter(m => m != null).map(m => m.resolvedFileName);
+            instance.dependencyGraph[path.normalize(containingFile)] = resolvedModules.filter(m => m != null).map(m => m.resolvedFileName);
             
             return resolvedModules;
         }


### PR DESCRIPTION
`instance.dependencyGraph` gets created using a raw `containingFile` value:
```ts
var servicesHost = {
    // ...
    resolveModuleNames: (moduleNames: string[], containingFile: string) => {
        // ...
        instance.dependencyGraph[containingFile] = ...
        // ...
    }
    // ...
}
```

But is later accessed with a normalized path:
```ts
function loader(contents) {
    // ...
    var filePath = path.normalize(this.resourcePath);
    // ...
    let additionalDependencies = instance.dependencyGraph[filePath];
    // ...
}
```

This breaks every scenario where `path.normalize` is not identity.

For example, in Windows, you get:

```
containingFile: 'C:/project/dir/file.ts'

path.normalize(containingFile): 'C:\\project\\dir\\file.ts'
```