### PR TITLE
Fail fast if expectedOutput does not exist

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -69,8 +69,7 @@ function createTest(test, testPath, options) {
             webpackOutput = path.join(testStagingPath, '.output'),
             originalExpectedOutput = path.join(testPath, 'expectedOutput-'+typescriptVersion);
         
-        assert.ok(fileExists(expectedOutput), 'The expectedOutput does not exist; there is nothing to compare against!\nCould not find this file: ' + expectedOutput)
-        assert.ok(fileExists(originalExpectedOutput), 'The originalExpectedOutput does not exist; there is nothing to compare against!\nCould not find this file: ' + expectedOutput)
+        assert.ok(fileExists(originalExpectedOutput), 'The originalExpectedOutput does not exist; there is nothing to compare against!\nCould not find this file: ' + originalExpectedOutput)
 
         if (saveOutputMode) {
             savedOutputs[test] = savedOutputs[test] || {};

--- a/test/run.js
+++ b/test/run.js
@@ -48,6 +48,16 @@ fs.readdirSync(__dirname).forEach(function(test) {
     }
 });
 
+function fileExists(path) {
+    var fileExists = true;
+    try {
+        fs.accessSync(path, fs.F_OK);
+    } catch (e) {
+        fileExists = false;
+    }
+    return fileExists;
+}
+
 function createTest(test, testPath, options) {
     return function(done) {
         this.timeout(60000); // sometimes it just takes awhile
@@ -59,6 +69,9 @@ function createTest(test, testPath, options) {
             webpackOutput = path.join(testStagingPath, '.output'),
             originalExpectedOutput = path.join(testPath, 'expectedOutput-'+typescriptVersion);
         
+        assert.ok(fileExists(expectedOutput), 'The expectedOutput does not exist; there is nothing to compare against!\nCould not find this file: ' + expectedOutput)
+        assert.ok(fileExists(originalExpectedOutput), 'The originalExpectedOutput does not exist; there is nothing to compare against!\nCould not find this file: ' + expectedOutput)
+
         if (saveOutputMode) {
             savedOutputs[test] = savedOutputs[test] || {};
             var regularSavedOutput = savedOutputs[test].regular = savedOutputs[test].regular || {};

--- a/test/run.js
+++ b/test/run.js
@@ -69,7 +69,7 @@ function createTest(test, testPath, options) {
             webpackOutput = path.join(testStagingPath, '.output'),
             originalExpectedOutput = path.join(testPath, 'expectedOutput-'+typescriptVersion);
         
-        assert.ok(fileExists(originalExpectedOutput), 'The expected output does not exist; there is nothing to compare against! Has the expected output been created?\nCould not find this file: ' + originalExpectedOutput)
+        assert.ok(fileExists(originalExpectedOutput), 'The expected output does not exist; there is nothing to compare against! Has the expected output been created?\nCould not find: ' + originalExpectedOutput)
 
         if (saveOutputMode) {
             savedOutputs[test] = savedOutputs[test] || {};

--- a/test/run.js
+++ b/test/run.js
@@ -69,7 +69,7 @@ function createTest(test, testPath, options) {
             webpackOutput = path.join(testStagingPath, '.output'),
             originalExpectedOutput = path.join(testPath, 'expectedOutput-'+typescriptVersion);
         
-        assert.ok(fileExists(originalExpectedOutput), 'The originalExpectedOutput does not exist; there is nothing to compare against!\nCould not find this file: ' + originalExpectedOutput)
+        assert.ok(fileExists(originalExpectedOutput), 'The expected output does not exist; there is nothing to compare against! Has the expected output been created?\nCould not find this file: ' + originalExpectedOutput)
 
         if (saveOutputMode) {
             savedOutputs[test] = savedOutputs[test] || {};


### PR DESCRIPTION
I realised that the tests were failing because there is no expected output.  I made the tests check at the beginning if there is an output to assert against and fail immediately if not.  I hope this makes the test pack faster and the reason for failure more obvious.

We should probably get rid of the 1.9 expected output by the way; there is no TS 1.9 and will not be.  We should likely adjust the build matrices to remove typescript@next since we don't have valid output for that either.