### PR TITLE
Ensure test data can be regenerated 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,12 +65,26 @@ filesystem output (typically `bundle.js` and possibly `bundle.js.map`) and any
 console output. stdout should go in `output.txt` and stderr should go in
 `err.txt`.
 
+If you would like to run just a single test then supply the name of it like so:
+
+`npm test -- --single-test declarationOutput`
+
+### Regenerating test data
+
 As a convenience it is possible to regenerate the expected output from the 
 actual output. This is useful when creating new tests and also when making a
-change that affects multiple existing tests. To run use 
-`npm test -- --save-output`. Note that all tests will automatically pass when
+change that affects multiple existing tests. To run use:
+
+`npm test -- --save-output`. 
+
+Note that all tests will automatically pass when
 using this feature. You should double check the generated files to make sure
 the output is indeed correct.
+
+If you would like to regenerate a single test then combine `--save-output` with 
+`--single-test` like so:
+
+`npm test -- --save-output --single-test declarationOutput`
 
 The test harness additionally supports watch mode since that is such an
 integral part of webpack. The initial state is as described above. After the

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^2.1.0",
     "rimraf": "^2.4.2",
-    "typescript": "^1.6.2",
-    "webpack": "^1.11.0"
+    "typescript": "^2.0.3",
+    "webpack": "^1.13.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^2.1.0",
     "rimraf": "^2.4.2",
-    "typescript": "^2.0.3",
-    "webpack": "^1.13.2"
+    "typescript": "^1.6.2",
+    "webpack": "^1.11.0"
   }
 }

--- a/test/run.js
+++ b/test/run.js
@@ -13,7 +13,10 @@ var glob = require('glob');
 // force colors on for tests since expected output has colors
 require('colors').enabled = true;
 
-var saveOutputMode = process.argv.indexOf('--save-output') != -1;
+var saveOutputMode = process.argv.indexOf('--save-output') !== -1;
+
+var indexOfSingleTest = process.argv.indexOf('--single-test');
+var singleTestToRun = indexOfSingleTest !== -1 && process.argv[indexOfSingleTest + 1];
 
 var savedOutputs = {};
 
@@ -37,6 +40,8 @@ fs.readdirSync(__dirname).forEach(function(test) {
         
         if (test == 'issue81' && semver.lt(typescript.version, '1.7.0-0')) return;
         
+        if (singleTestToRun && singleTestToRun !== test) return;
+
         describe(test, function() {
             it('should have the correct output', createTest(test, testPath, {}));
             

--- a/test/run.js
+++ b/test/run.js
@@ -69,8 +69,7 @@ function createTest(test, testPath, options) {
             webpackOutput = path.join(testStagingPath, '.output'),
             originalExpectedOutput = path.join(testPath, 'expectedOutput-'+typescriptVersion);
         
-        assert.ok(fileExists(expectedOutput), 'The expectedOutput does not exist; there is nothing to compare against!\nCould not find this file: ' + expectedOutput)
-        assert.ok(fileExists(originalExpectedOutput), 'The originalExpectedOutput does not exist; there is nothing to compare against!\nCould not find this file: ' + expectedOutput)
+        assert.ok(fileExists(originalExpectedOutput), 'The originalExpectedOutput does not exist; there is nothing to compare against!\nCould not find this file: ' + originalExpectedOutput)
 
         if (saveOutputMode) {
             savedOutputs[test] = savedOutputs[test] || {};

--- a/test/run.js
+++ b/test/run.js
@@ -48,6 +48,16 @@ fs.readdirSync(__dirname).forEach(function(test) {
     }
 });
 
+function fileExists(path) {
+    var fileExists = true;
+    try {
+        fs.accessSync(path, fs.F_OK);
+    } catch (e) {
+        fileExists = false;
+    }
+    return fileExists;
+}
+
 function createTest(test, testPath, options) {
     return function(done) {
         this.timeout(60000); // sometimes it just takes awhile
@@ -59,6 +69,9 @@ function createTest(test, testPath, options) {
             webpackOutput = path.join(testStagingPath, '.output'),
             originalExpectedOutput = path.join(testPath, 'expectedOutput-'+typescriptVersion);
         
+        assert.ok(fileExists(expectedOutput), 'The expectedOutput does not exist; there is nothing to compare against!\nCould not find this file: ' + expectedOutput)
+        assert.ok(fileExists(originalExpectedOutput), 'The originalExpectedOutput does not exist; there is nothing to compare against!\nCould not find this file: ' + expectedOutput)
+
         if (saveOutputMode) {
             savedOutputs[test] = savedOutputs[test] || {};
             var regularSavedOutput = savedOutputs[test].regular = savedOutputs[test].regular || {};

--- a/test/run.js
+++ b/test/run.js
@@ -69,14 +69,14 @@ function createTest(test, testPath, options) {
             webpackOutput = path.join(testStagingPath, '.output'),
             originalExpectedOutput = path.join(testPath, 'expectedOutput-'+typescriptVersion);
         
-        assert.ok(fileExists(originalExpectedOutput), 'The expected output does not exist; there is nothing to compare against! Has the expected output been created?\nCould not find: ' + originalExpectedOutput)
-
         if (saveOutputMode) {
             savedOutputs[test] = savedOutputs[test] || {};
             var regularSavedOutput = savedOutputs[test].regular = savedOutputs[test].regular || {};
             var transpiledSavedOutput = savedOutputs[test].transpiled = savedOutputs[test].transpiled || {};
             var currentSavedOutput = options.transpile ? transpiledSavedOutput : regularSavedOutput;
             mkdirp.sync(originalExpectedOutput);
+        } else {
+            assert.ok(fileExists(originalExpectedOutput), 'The expected output does not exist; there is nothing to compare against! Has the expected output been created?\nCould not find: ' + originalExpectedOutput)
         }
         
         // copy all input to a staging area

--- a/test/run.js
+++ b/test/run.js
@@ -69,7 +69,7 @@ function createTest(test, testPath, options) {
             webpackOutput = path.join(testStagingPath, '.output'),
             originalExpectedOutput = path.join(testPath, 'expectedOutput-'+typescriptVersion);
         
-        assert.ok(fileExists(originalExpectedOutput), 'The expected output does not exist; there is nothing to compare against! Has the expected output been created?\nCould not find this file: ' + originalExpectedOutput)
+        assert.ok(fileExists(originalExpectedOutput), 'The expected output does not exist; there is nothing to compare against! Has the expected output been created?\nCould not find: ' + originalExpectedOutput)
 
         if (saveOutputMode) {
             savedOutputs[test] = savedOutputs[test] || {};

--- a/test/run.js
+++ b/test/run.js
@@ -69,7 +69,7 @@ function createTest(test, testPath, options) {
             webpackOutput = path.join(testStagingPath, '.output'),
             originalExpectedOutput = path.join(testPath, 'expectedOutput-'+typescriptVersion);
         
-        assert.ok(fileExists(originalExpectedOutput), 'The originalExpectedOutput does not exist; there is nothing to compare against!\nCould not find this file: ' + originalExpectedOutput)
+        assert.ok(fileExists(originalExpectedOutput), 'The expected output does not exist; there is nothing to compare against! Has the expected output been created?\nCould not find this file: ' + originalExpectedOutput)
 
         if (saveOutputMode) {
             savedOutputs[test] = savedOutputs[test] || {};

--- a/test/run.js
+++ b/test/run.js
@@ -53,14 +53,14 @@ fs.readdirSync(__dirname).forEach(function(test) {
     }
 });
 
-function fileExists(path) {
-    var fileExists = true;
+function pathExists(path) {
+    var pathExists = true;
     try {
         fs.accessSync(path, fs.F_OK);
     } catch (e) {
-        fileExists = false;
+        pathExists = false;
     }
-    return fileExists;
+    return pathExists;
 }
 
 function createTest(test, testPath, options) {
@@ -81,7 +81,7 @@ function createTest(test, testPath, options) {
             var currentSavedOutput = options.transpile ? transpiledSavedOutput : regularSavedOutput;
             mkdirp.sync(originalExpectedOutput);
         } else {
-            assert.ok(fileExists(originalExpectedOutput), 'The expected output does not exist; there is nothing to compare against! Has the expected output been created?\nCould not find: ' + originalExpectedOutput)
+            assert.ok(pathExists(originalExpectedOutput), 'The expected output does not exist; there is nothing to compare against! Has the expected output been created?\nCould not find: ' + originalExpectedOutput)
         }
         
         // copy all input to a staging area


### PR DESCRIPTION
when the test data doesn't exist in the first place and is being regenerated with `--save-output`

Also enable the running of a single test using `npm test -- --single-test testname` (documented in `CONTRIBUTING.md`)