### PR TITLE
Rollback of "watch-run" logic

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -527,8 +527,7 @@ function ensureTypeScriptInstance(loaderOptions: LoaderOptions, loader: any): { 
 
     // manually update changed files
     loader._compiler.plugin("watch-run", (watching, cb) => {
-        var mtimes = watching.compiler.fileTimestamps ||
-                     watching.compiler.watchFileSystem.watcher.mtimes;
+        var mtimes = watching.compiler.watchFileSystem.watcher.mtimes;
         Object.keys(mtimes)
             .filter(filePath => !!filePath.match(/\.tsx?$|\.jsx?$/))
             .forEach(filePath => {


### PR DESCRIPTION
Reverting [old change](https://github.com/TypeStrong/ts-loader/pull/167) which has broken webpack hot module reloading. Issue #321

