### PR TITLE
Add test for handling re-exported const enums (issue #376)

### DIFF
--- a/src/after-compile.ts
+++ b/src/after-compile.ts
@@ -100,7 +100,7 @@ function determineFilesToCheckForErrors(
     } else if (modifiedFiles) {
         // check all modified files, and all dependants
         Object.keys(modifiedFiles).forEach(modifiedFileName => {
-            collectAllDependants(instance.reverseDependencyGraph, modifiedFileName)
+            utils.collectAllDependants(instance.reverseDependencyGraph, modifiedFileName)
                 .forEach(fileName => {
                     filesToCheckForErrors[fileName] = files[fileName];
                 });
@@ -191,28 +191,6 @@ function removeTSLoaderErrors(errors: interfaces.WebpackError[]) {
             length--;
         }
     }
-}
-
-/**
- * Recursively collect all possible dependants of passed file
- */
-function collectAllDependants(
-    reverseDependencyGraph: interfaces.ReverseDependencyGraph,
-    fileName: string,
-    collected: {[file:string]: boolean} = {}
-): string[] {
-    const result = {};
-    result[fileName] = true;
-    collected[fileName] = true;
-    if (reverseDependencyGraph[fileName]) {
-        Object.keys(reverseDependencyGraph[fileName]).forEach(dependantFileName => {
-            if (!collected[dependantFileName]) {
-                collectAllDependants(reverseDependencyGraph, dependantFileName, collected)
-                    .forEach(fName => result[fName] = true);
-            }
-        });
-    }
-    return Object.keys(result);
 }
 
 export = makeAfterCompile;

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ function getEmit(
 
     // Additionally make this file dependent on all imported files as well
     // as any deeper recursive dependencies
-    let additionalDependencies = utils.collectAllDependencies(instance.dependencyGraph, filePath, {});
+    let additionalDependencies = utils.collectAllDependencies(instance.dependencyGraph, filePath);
     if (additionalDependencies) {
         additionalDependencies.forEach(loader.addDependency.bind(loader));
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,8 +110,9 @@ function getEmit(
     const allDefinitionFiles = Object.keys(instance.files).filter(fp => definitionFileRegex.test(fp));
     allDefinitionFiles.forEach(loader.addDependency.bind(loader));
 
-    // Additionally make this file dependent on all imported files
-    let additionalDependencies = instance.dependencyGraph[filePath];
+    // Additionally make this file dependent on all imported files as well
+    // as any deeper recursive dependencies
+    let additionalDependencies = utils.collectAllDependencies(instance.dependencyGraph, filePath, {});
     if (additionalDependencies) {
         additionalDependencies.forEach(loader.addDependency.bind(loader));
     }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -133,7 +133,7 @@ export interface TSInstances {
     [name: string]: TSInstance;
 }
 
-interface DependencyGraph {
+export interface DependencyGraph {
     [file: string]: string[];
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,3 +86,48 @@ export function appendTsSuffixIfMatch(patterns: RegExp[], path: string): string 
     }
     return path;
 }
+
+/**
+ * Recursively collect all possible dependants of passed file
+ */
+export function collectAllDependants(
+    reverseDependencyGraph: interfaces.ReverseDependencyGraph,
+    fileName: string,
+    collected: {[file:string]: boolean} = {}
+): string[] {
+    const result = {};
+    result[fileName] = true;
+    collected[fileName] = true;
+    if (reverseDependencyGraph[fileName]) {
+        Object.keys(reverseDependencyGraph[fileName]).forEach(dependantFileName => {
+            if (!collected[dependantFileName]) {
+                collectAllDependants(reverseDependencyGraph, dependantFileName, collected)
+                    .forEach(fName => result[fName] = true);
+            }
+        });
+    }
+    return Object.keys(result);
+}
+
+/**
+ * Recursively collect all possible dependencies of passed file
+ */
+export function collectAllDependencies(
+    dependencyGraph: interfaces.DependencyGraph,
+    filePath: string,
+    collected: {[file:string]: boolean} = {}
+): string[] {
+    const result = {};
+    result[filePath] = true;
+    collected[filePath] = true;
+    let directDependencies = dependencyGraph[filePath]; 
+    if (directDependencies) {
+        directDependencies.forEach(dependencyFilePath => {
+            if (!collected[dependencyFilePath]) {
+                collectAllDependencies(dependencyGraph, dependencyFilePath, collected)
+                    .forEach(fPath => result[fPath] = true);
+            }
+        });
+    }
+    return Object.keys(result);
+}

--- a/test/comparison-tests/constEnumReExportWatch/app.ts
+++ b/test/comparison-tests/constEnumReExportWatch/app.ts
@@ -1,0 +1,3 @@
+import { BarEnum } from './foo';
+
+console.log(BarEnum.Bar);

--- a/test/comparison-tests/constEnumReExportWatch/bar.ts
+++ b/test/comparison-tests/constEnumReExportWatch/bar.ts
@@ -1,0 +1,3 @@
+export const enum BarEnum {
+    Bar = 1
+};

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/bundle.js
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/bundle.js
@@ -1,0 +1,52 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	"use strict";
+	console.log(1 /* Bar */);
+
+
+/***/ }
+/******/ ]);

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/bundle.transpiled.js
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/bundle.transpiled.js
@@ -1,0 +1,74 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	var foo_1 = __webpack_require__(1);
+	console.log(foo_1.BarEnum.Bar);
+
+
+/***/ },
+/* 1 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	var bar_1 = __webpack_require__(2);
+	exports.BarEnum = bar_1.BarEnum;
+
+
+/***/ },
+/* 2 */
+/***/ function(module, exports) {
+
+	"use strict";
+	(function (BarEnum) {
+	    BarEnum[BarEnum["Bar"] = 1] = "Bar";
+	})(exports.BarEnum || (exports.BarEnum = {}));
+	var BarEnum = exports.BarEnum;
+	;
+
+
+/***/ }
+/******/ ]);

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/output.transpiled.txt
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/output.transpiled.txt
@@ -1,0 +1,6 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.87 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 310 bytes [rendered]
+    [0] ./.test/constEnumReExportWatch/app.ts 76 bytes {0} [built]
+    [1] ./.test/constEnumReExportWatch/foo.ts 77 bytes {0} [built]
+    [2] ./.test/constEnumReExportWatch/bar.ts 157 bytes {0} [built]

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/output.txt
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/output.txt
@@ -1,0 +1,4 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.43 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 40 bytes [rendered]
+    [0] ./.test/constEnumReExportWatch/app.ts 40 bytes {0} [built]

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/patch0/bundle.js
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/patch0/bundle.js
@@ -1,0 +1,52 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	"use strict";
+	console.log(2 /* Bar */);
+
+
+/***/ }
+/******/ ]);

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/patch0/bundle.transpiled.js
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/patch0/bundle.transpiled.js
@@ -1,0 +1,74 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	var foo_1 = __webpack_require__(1);
+	console.log(foo_1.BarEnum.Bar);
+
+
+/***/ },
+/* 1 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	var bar_1 = __webpack_require__(2);
+	exports.BarEnum = bar_1.BarEnum;
+
+
+/***/ },
+/* 2 */
+/***/ function(module, exports) {
+
+	"use strict";
+	(function (BarEnum) {
+	    BarEnum[BarEnum["Bar"] = 2] = "Bar";
+	})(exports.BarEnum || (exports.BarEnum = {}));
+	var BarEnum = exports.BarEnum;
+	;
+
+
+/***/ }
+/******/ ]);

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/patch0/output.transpiled.txt
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/patch0/output.transpiled.txt
@@ -1,0 +1,6 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.87 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 310 bytes [rendered]
+    [0] ./.test/constEnumReExportWatch/app.ts 76 bytes {0}
+    [1] ./.test/constEnumReExportWatch/foo.ts 77 bytes {0}
+    [2] ./.test/constEnumReExportWatch/bar.ts 157 bytes {0} [built]

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/patch0/output.txt
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.0/patch0/output.txt
@@ -1,0 +1,4 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.43 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 40 bytes [rendered]
+    [0] ./.test/constEnumReExportWatch/app.ts 40 bytes {0} [built]

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/bundle.js
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/bundle.js
@@ -1,0 +1,52 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	"use strict";
+	console.log(1 /* Bar */);
+
+
+/***/ }
+/******/ ]);

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/bundle.transpiled.js
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/bundle.transpiled.js
@@ -1,0 +1,74 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	var foo_1 = __webpack_require__(1);
+	console.log(foo_1.BarEnum.Bar);
+
+
+/***/ },
+/* 1 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	var bar_1 = __webpack_require__(2);
+	exports.BarEnum = bar_1.BarEnum;
+
+
+/***/ },
+/* 2 */
+/***/ function(module, exports) {
+
+	"use strict";
+	(function (BarEnum) {
+	    BarEnum[BarEnum["Bar"] = 1] = "Bar";
+	})(exports.BarEnum || (exports.BarEnum = {}));
+	var BarEnum = exports.BarEnum;
+	;
+
+
+/***/ }
+/******/ ]);

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/output.transpiled.txt
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/output.transpiled.txt
@@ -1,0 +1,6 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.87 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 310 bytes [rendered]
+    [0] ./.test/constEnumReExportWatch/app.ts 76 bytes {0} [built]
+    [1] ./.test/constEnumReExportWatch/foo.ts 77 bytes {0} [built]
+    [2] ./.test/constEnumReExportWatch/bar.ts 157 bytes {0} [built]

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/output.txt
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/output.txt
@@ -1,0 +1,4 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.43 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 40 bytes [rendered]
+    [0] ./.test/constEnumReExportWatch/app.ts 40 bytes {0} [built]

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/patch0/bundle.js
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/patch0/bundle.js
@@ -1,0 +1,52 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	"use strict";
+	console.log(2 /* Bar */);
+
+
+/***/ }
+/******/ ]);

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/patch0/bundle.transpiled.js
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/patch0/bundle.transpiled.js
@@ -1,0 +1,74 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	var foo_1 = __webpack_require__(1);
+	console.log(foo_1.BarEnum.Bar);
+
+
+/***/ },
+/* 1 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+	var bar_1 = __webpack_require__(2);
+	exports.BarEnum = bar_1.BarEnum;
+
+
+/***/ },
+/* 2 */
+/***/ function(module, exports) {
+
+	"use strict";
+	(function (BarEnum) {
+	    BarEnum[BarEnum["Bar"] = 2] = "Bar";
+	})(exports.BarEnum || (exports.BarEnum = {}));
+	var BarEnum = exports.BarEnum;
+	;
+
+
+/***/ }
+/******/ ]);

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/patch0/output.transpiled.txt
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/patch0/output.transpiled.txt
@@ -1,0 +1,6 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.87 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 310 bytes [rendered]
+    [0] ./.test/constEnumReExportWatch/app.ts 76 bytes {0}
+    [1] ./.test/constEnumReExportWatch/foo.ts 77 bytes {0}
+    [2] ./.test/constEnumReExportWatch/bar.ts 157 bytes {0} [built]

--- a/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/patch0/output.txt
+++ b/test/comparison-tests/constEnumReExportWatch/expectedOutput-2.1/patch0/output.txt
@@ -1,0 +1,4 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  1.43 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 40 bytes [rendered]
+    [0] ./.test/constEnumReExportWatch/app.ts 40 bytes {0} [built]

--- a/test/comparison-tests/constEnumReExportWatch/foo.ts
+++ b/test/comparison-tests/constEnumReExportWatch/foo.ts
@@ -1,0 +1,1 @@
+export { BarEnum } from './bar';

--- a/test/comparison-tests/constEnumReExportWatch/patch0/bar.ts
+++ b/test/comparison-tests/constEnumReExportWatch/patch0/bar.ts
@@ -1,0 +1,3 @@
+export const enum BarEnum {
+    Bar = 2
+};

--- a/test/comparison-tests/constEnumReExportWatch/tsconfig.json
+++ b/test/comparison-tests/constEnumReExportWatch/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+	},
+	"exclude": [
+		"patch*"
+	]
+}

--- a/test/comparison-tests/constEnumReExportWatch/webpack.config.js
+++ b/test/comparison-tests/constEnumReExportWatch/webpack.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+    entry: './app.ts',
+    output: {
+        filename: 'bundle.js'
+    },
+    resolve: {
+        extensions: ['', '.ts', '.js']
+    },
+    module: {
+        loaders: [
+            { test: /\.ts$/, loader: 'ts-loader' }
+        ]
+    }
+}
+
+// for test harness purposes only, you would not need this in a normal project
+module.exports.resolveLoader = { alias: { 'ts-loader': require('path').join(__dirname, "../../index.js") } }

--- a/test/comparison-tests/simpleDependency/expectedOutput-1.6/patch0/output.txt
+++ b/test/comparison-tests/simpleDependency/expectedOutput-1.6/patch0/output.txt
@@ -1,7 +1,7 @@
     Asset     Size  Chunks             Chunk Names
 bundle.js  1.71 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 155 bytes [rendered]
-    [0] ./.test/simpleDependency/app.ts 37 bytes {0} [1 error]
+    [0] ./.test/simpleDependency/app.ts 37 bytes {0} [built] [1 error]
     [1] ./.test/simpleDependency/dep.ts 56 bytes {0} [built]
     [2] ./.test/simpleDependency/deeperDep.ts 62 bytes {0} [built]
 

--- a/test/comparison-tests/simpleDependency/expectedOutput-1.6/patch1/output.txt
+++ b/test/comparison-tests/simpleDependency/expectedOutput-1.6/patch1/output.txt
@@ -1,6 +1,6 @@
     Asset     Size  Chunks             Chunk Names
 bundle.js  1.71 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 155 bytes [rendered]
-    [0] ./.test/simpleDependency/app.ts 37 bytes {0}
+    [0] ./.test/simpleDependency/app.ts 37 bytes {0} [built]
     [1] ./.test/simpleDependency/dep.ts 56 bytes {0} [built]
     [2] ./.test/simpleDependency/deeperDep.ts 62 bytes {0} [built]

--- a/test/comparison-tests/simpleDependency/expectedOutput-1.7/patch0/output.txt
+++ b/test/comparison-tests/simpleDependency/expectedOutput-1.7/patch0/output.txt
@@ -1,7 +1,7 @@
     Asset     Size  Chunks             Chunk Names
 bundle.js  1.71 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 155 bytes [rendered]
-    [0] ./.test/simpleDependency/app.ts 37 bytes {0} [1 error]
+    [0] ./.test/simpleDependency/app.ts 37 bytes {0} [built] [1 error]
     [1] ./.test/simpleDependency/dep.ts 56 bytes {0} [built]
     [2] ./.test/simpleDependency/deeperDep.ts 62 bytes {0} [built]
 

--- a/test/comparison-tests/simpleDependency/expectedOutput-1.7/patch1/output.txt
+++ b/test/comparison-tests/simpleDependency/expectedOutput-1.7/patch1/output.txt
@@ -1,6 +1,6 @@
     Asset     Size  Chunks             Chunk Names
 bundle.js  1.71 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 155 bytes [rendered]
-    [0] ./.test/simpleDependency/app.ts 37 bytes {0}
+    [0] ./.test/simpleDependency/app.ts 37 bytes {0} [built]
     [1] ./.test/simpleDependency/dep.ts 56 bytes {0} [built]
     [2] ./.test/simpleDependency/deeperDep.ts 62 bytes {0} [built]

--- a/test/comparison-tests/simpleDependency/expectedOutput-1.8/patch0/output.txt
+++ b/test/comparison-tests/simpleDependency/expectedOutput-1.8/patch0/output.txt
@@ -1,7 +1,7 @@
     Asset     Size  Chunks             Chunk Names
 bundle.js  1.75 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 197 bytes [rendered]
-    [0] ./.test/simpleDependency/app.ts 51 bytes {0} [1 error]
+    [0] ./.test/simpleDependency/app.ts 51 bytes {0} [built] [1 error]
     [1] ./.test/simpleDependency/dep.ts 70 bytes {0} [built]
     [2] ./.test/simpleDependency/deeperDep.ts 76 bytes {0} [built]
 

--- a/test/comparison-tests/simpleDependency/expectedOutput-1.8/patch1/output.txt
+++ b/test/comparison-tests/simpleDependency/expectedOutput-1.8/patch1/output.txt
@@ -1,6 +1,6 @@
     Asset     Size  Chunks             Chunk Names
 bundle.js  1.75 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 197 bytes [rendered]
-    [0] ./.test/simpleDependency/app.ts 51 bytes {0}
+    [0] ./.test/simpleDependency/app.ts 51 bytes {0} [built]
     [1] ./.test/simpleDependency/dep.ts 70 bytes {0} [built]
     [2] ./.test/simpleDependency/deeperDep.ts 76 bytes {0} [built]

--- a/test/comparison-tests/simpleDependency/expectedOutput-2.0/patch0/output.txt
+++ b/test/comparison-tests/simpleDependency/expectedOutput-2.0/patch0/output.txt
@@ -1,7 +1,7 @@
     Asset     Size  Chunks             Chunk Names
 bundle.js  1.75 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 197 bytes [rendered]
-    [0] ./.test/simpleDependency/app.ts 51 bytes {0} [1 error]
+    [0] ./.test/simpleDependency/app.ts 51 bytes {0} [built] [1 error]
     [1] ./.test/simpleDependency/dep.ts 70 bytes {0} [built]
     [2] ./.test/simpleDependency/deeperDep.ts 76 bytes {0} [built]
 

--- a/test/comparison-tests/simpleDependency/expectedOutput-2.0/patch1/output.txt
+++ b/test/comparison-tests/simpleDependency/expectedOutput-2.0/patch1/output.txt
@@ -1,6 +1,6 @@
     Asset     Size  Chunks             Chunk Names
 bundle.js  1.75 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 197 bytes [rendered]
-    [0] ./.test/simpleDependency/app.ts 51 bytes {0}
+    [0] ./.test/simpleDependency/app.ts 51 bytes {0} [built]
     [1] ./.test/simpleDependency/dep.ts 70 bytes {0} [built]
     [2] ./.test/simpleDependency/deeperDep.ts 76 bytes {0} [built]

--- a/test/comparison-tests/simpleDependency/expectedOutput-2.1/patch0/output.txt
+++ b/test/comparison-tests/simpleDependency/expectedOutput-2.1/patch0/output.txt
@@ -1,7 +1,7 @@
     Asset     Size  Chunks             Chunk Names
 bundle.js  1.75 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 197 bytes [rendered]
-    [0] ./.test/simpleDependency/app.ts 51 bytes {0} [1 error]
+    [0] ./.test/simpleDependency/app.ts 51 bytes {0} [built] [1 error]
     [1] ./.test/simpleDependency/dep.ts 70 bytes {0} [built]
     [2] ./.test/simpleDependency/deeperDep.ts 76 bytes {0} [built]
 

--- a/test/comparison-tests/simpleDependency/expectedOutput-2.1/patch1/output.txt
+++ b/test/comparison-tests/simpleDependency/expectedOutput-2.1/patch1/output.txt
@@ -1,6 +1,6 @@
     Asset     Size  Chunks             Chunk Names
 bundle.js  1.75 kB       0  [emitted]  main
 chunk    {0} bundle.js (main) 197 bytes [rendered]
-    [0] ./.test/simpleDependency/app.ts 51 bytes {0}
+    [0] ./.test/simpleDependency/app.ts 51 bytes {0} [built]
     [1] ./.test/simpleDependency/dep.ts 70 bytes {0} [built]
     [2] ./.test/simpleDependency/deeperDep.ts 76 bytes {0} [built]


### PR DESCRIPTION
Add a test for issue #376.

I'm not sure if the transpile-mode expected output is correct, it looks like const enums are always preserved in that mode.