### PR TITLE
Using ts loader in projects with shared node modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,30 @@ export default {
 ```
 
 
+##### sharedNodeModules *(boolean) (default=false)*
+In some projects node_modules folder is shared by several npm modules like:
+```
+\_
+  \_node_modules (folder)
+  \_first-module
+    \_node_modules (symbolic link to ../node_modules)
+    \_...
+  \_second-module
+    \_node_modules (symbolic link to ../node_modules)
+    \_...
+```
+Setting sharedNodeModules=true allows avoid including the same files for compilation from node_modules several times. For example, _first_module_ and _second_module_ uses jQuery. So with sharedNodeModules=false the following files are added for compilation:
+```
+/first-module/node_modules/@types/jquery/index.d.ts
+/second-module/node_modules/@types/jquery/index.d.ts
+```
+With sharedNodeModules=true only one such file will be compiled.
+
+
+##### skipLibsErrorCheck *(boolean) (default=false)*
+If 'true' the plugin skips checking errors in files that are placed in 'node_modules' folder(s) and it's subfolders.
+
+
 ### Loading other resources and code splitting
 
 Loading css and other resources is possible but you will need to make sure that

--- a/src/after-compile.ts
+++ b/src/after-compile.ts
@@ -113,7 +113,7 @@ function determineFilesToCheckForErrors(
             filesToCheckForErrors[fileWithErrorName] = filesWithErrors[fileWithErrorName]
         );
     }
-    return filesToCheckForErrors;
+    return filterFilesToCheckForErrors(instance, filesToCheckForErrors);
 }
 
 function provideErrorsToWebpack(
@@ -213,6 +213,30 @@ function collectAllDependants(
         });
     }
     return Object.keys(result);
+}
+
+/**
+ * Filters files to check according to loader options.
+ * @return {interfaces.TSFiles} filtered files.
+ */
+function filterFilesToCheckForErrors(instance: interfaces.TSInstance, filesToCheckForErrors: interfaces.TSFiles): interfaces.TSFiles {
+    if (instance.loaderOptions.skipLibsErrorCheck) {
+        filesToCheckForErrors = filterLibs(filesToCheckForErrors)
+    }
+    return filesToCheckForErrors
+}
+
+/**
+ * Filters all files that are placed in 'node_modules'.
+ * @return {interfaces.TSFiles} filtered files.
+ */
+function filterLibs(filesToCheckForErrors: interfaces.TSFiles): interfaces.TSFiles {
+    return Object.keys(filesToCheckForErrors)
+        .filter(key => key.indexOf('node_modules') < 0)
+        .reduce((acc: interfaces.TSFiles, key: string) => {
+            acc[key] = filesToCheckForErrors[key];
+            return acc;
+        }, {})
 }
 
 export = makeAfterCompile;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -155,6 +155,8 @@ export interface LoaderOptions {
     visualStudioErrorFormat: boolean;
     compilerOptions: typescript.CompilerOptions;
     appendTsSuffixTo: RegExp[];
+    sharedNodeModules: boolean;
+    skipLibsErrorCheck: boolean;
 }
 
 export interface TSFile {


### PR DESCRIPTION
Hi,

I'd like to suggest small extension for ts-loader that can be useful for projects with many local npm modules. Below I describe configuration of such project, issues that we've run into, and suggested changes to overcome the issues.

## Project structure

In our project we separate sources into several npm modules with one root application module like:

```
app-shell
	|_ui-common
	|_ui-react
	|_ui-state
	|_...
```
With such structure we had performance issue during build, because each npm module has its own node_modules and there are many duplicated libraries. We resolved it by using one root node_modules and symbolic links in npm modules. So we have file structure like this one:
```
node_modules (folder)
app-shell
	|_node_modules (symlink to ../node_modules)
	|_...
ui-common
	|_node_modules (symlink to ../node_modules)
	|_...
...		
```

## Using ts-loader in our project

We use ts-loader with webpack and webpack-dev-server in the root 'app-shell' module. With basic configuration we don't have any issue with neither webpack nor webpack-dev-server, but there is one problem with such config: hot reload works only for the root npm module. So we add the ModuleResolver to the webpack-dev-server config to enable hot reload for any our module. For example if you work with 'ui-react' and 'shell' modules and you want to enable hot reload for them, the config will be the following:
```javascript
...
const root = path.resolve('../../..');
const conf = {};
conf['ui-react'] = root + '/ui-react/src/index.ts';
conf['shell'] = root + '/shell/src/index.ts';

const ModuleResolver = {
    apply: function(resolver) {
        resolver.plugin('module', function(request, callback) {
            if (conf[request.request]) {
                var obj = {
                    path: request.path,
                    request: conf[request.request],
                    query: request.query,
                    directory: request.directory
                };
                this.doResolve(['file'], obj, callback);
            }
            else {
                callback();
            }
        });
    }
};
...
    plugins: [
        new webpack.ResolverPlugin([ModuleResolver]),
        ...
    ]
...
```

## Issues

### Duplication of files from node_modules

Because sharing of node_modules, the same *.ts, *.d.ts and *.tsx files are added in *instance.files* many times with different patch. For example:

!(/after-compile.png)

This leads to the following consequences:
- performance degradation
- compilation error in after-compile hook due to including identical d.ts files several times:
```
ERROR in .../ui-react/node_modules/@types/jquery/index.d.ts
(623,5): error TS2374: Duplicate string index signature.

ERROR in .../ui-react/node_modules/@types/jquery/index.d.ts
(2872,5): error TS2374: Duplicate string index signature.

ERROR in .../ui-react/node_modules/@types/jquery/index.d.ts
(2873,5): error TS2375: Duplicate number index signature.

ERROR in .../ui-react/node_modules/@types/jquery/index.d.ts
(3246,5): error TS2300: Duplicate identifier 'export='.

ERROR in .../app-shell/node_modules/@types/jquery/index.d.ts
(3246,5): error TS2300: Duplicate identifier 'export='.
```

### Verification of files from node_modules

After-compile hook checks errors in d.ts files. And it does it for all such files including libraries installed in node_modules. There are two problems with that:
- if a lib has been published, we can assume that it is correct, because it should be compiled and tested before publishing. Such assumption looks reasonable because during build we cannot verify all software that we use.
- There is an issue with after-compile hook: compiler detects errors in jquery d.ts file even if it doesn't have any duplicates in instance.files. On compilation stage in loader(...) all is good, so this issue leads to an inconsistency in the plugin behavior - it works with webpack, but it fails with webpack-dev-server with the following error:
```
ERROR in /Users/bogdan/hg/eis-genesis/prototypes/genesis-web/app-shell/node_modules/@types/jquery/index.d.ts
(3246,5): error TS2300: Duplicate identifier 'export='.
```

## Suggested changes

Because described problems occur only in specific configuration, it wouldn't be reasonable to change current behavior of the plugin. So in the pull request I've added file caching for node_modules and skipping node_modules error checking, and these features are disabled by default and can be enabled in loader options.

## Testing

The changes were tested by full set of tests for all combinations of _skipLibsErrorCheck_ and _sharedNodeModules_.