### PR TITLE
Fix bug when "extend"ing a tsconfig that specifies "allowJs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ts-loader works very well in combination with [babel](https://babeljs.io/) and [
 
 ### Contributing
 
-This is your TypeScript loader! We want you to help make it even better. Please feel free to contribute; see the [contributer's guide](CONTRIBUTING.md) to get started.
+This is your TypeScript loader! We want you to help make it even better. Please feel free to contribute; see the [contributor's guide](CONTRIBUTING.md) to get started.
 
 ### Installation
 

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -89,7 +89,7 @@ export function ensureTypeScriptInstance(
     }
 
     // if allowJs is set then we should accept js(x) files
-    const scriptRegex = configFile.config.compilerOptions.allowJs && loaderOptions.entryFileIsJs
+    const scriptRegex = configParseResult.options.allowJs && loaderOptions.entryFileIsJs
         ? /\.tsx?$|\.jsx?$/i
         : /\.tsx?$/i;
 


### PR DESCRIPTION
When ts-loader checks the `allowJs` flag of your tsconfig, it should be checking the fully loaded config, including all "extend"ed tsconfig files.

I also fixed a spelling mistake in the README that I noticed while working.