### PR TITLE
Make comparison tests tolerant to byte differences in output files

### DIFF
--- a/test/comparison-tests/create-and-execute-test.js
+++ b/test/comparison-tests/create-and-execute-test.js
@@ -368,6 +368,8 @@ function getNormalisedFileContent(file, location, test) {
             ? normaliseString(originalContent)
                 // We really don't care if it's 4.31 kB; it's enough to know that it's 4 kB
                 .replace(/[.][\d]* kB/g, ' kB')
+                // We also don't want a difference in the number of bytes to fail the build
+                .replace(/ \d+ bytes /g, ' A-NUMBER-OF bytes ')
                 // Ignore whitespace between:     Asset     Size  Chunks             Chunk Names
                 .replace(/\s+Asset\s+Size\s+Chunks\s+Chunk Names/, '    Asset     Size  Chunks             Chunk Names')
             : normaliseString(originalContent);


### PR DESCRIPTION
which are to be expected between Windows and Linux due to line endings.

related to https://github.com/TypeStrong/ts-loader/pull/444 cc @herschel666