### PR TITLE
Add an additional check for js files before reusing isExternalLibaryImport (#620)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^3.1.0",
     "rimraf": "^2.4.2",
-    "typescript": "2.4.2",
+    "typescript": "^2.4.2",
     "typings": "^2.0.0",
     "webpack": "^2.2.0"
   }

--- a/src/servicesHost.ts
+++ b/src/servicesHost.ts
@@ -112,6 +112,14 @@ function resolveModuleNames(
     return resolvedModules;
 }
 
+function isJsImplementationOfTypings(
+    resolvedModule: ResolvedModule,
+    tsResolution: ResolvedModule
+) {
+    return resolvedModule.resolvedFileName.endsWith('js') && 
+            /node_modules(\\|\/).*\.d\.ts$/.test(tsResolution.resolvedFileName);
+}
+
 function resolveModuleName(
     resolveSync: ResolveSync,
     moduleResolutionHost: ModuleResolutionHost,
@@ -153,7 +161,7 @@ function resolveModuleName(
         };
         if (resolutionResult!) {
             if (resolutionResult!.resolvedFileName === tsResolutionResult.resolvedFileName ||
-                /node_modules(\\|\/).*\.d\.ts$/.test(tsResolutionResult.resolvedFileName)) {
+                isJsImplementationOfTypings(resolutionResult!, tsResolutionResult)) {
                 resolutionResult!.isExternalLibraryImport = tsResolutionResult.isExternalLibraryImport;
             }
         } else {

--- a/test/comparison-tests/localTsImplementationOfTypings/app.ts
+++ b/test/comparison-tests/localTsImplementationOfTypings/app.ts
@@ -1,0 +1,3 @@
+import myComponent = require('api');
+
+console.log(myComponent);

--- a/test/comparison-tests/localTsImplementationOfTypings/expectedOutput-2.4/bundle.js
+++ b/test/comparison-tests/localTsImplementationOfTypings/expectedOutput-2.4/bundle.js
@@ -1,0 +1,94 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+exports.__esModule = true;
+function sayHello(name) {
+    return "Hello, " + name + "!";
+}
+exports.sayHello = sayHello;
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+exports.__esModule = true;
+var myComponent = __webpack_require__(0);
+console.log(myComponent);
+
+
+/***/ })
+/******/ ]);

--- a/test/comparison-tests/localTsImplementationOfTypings/expectedOutput-2.4/output.txt
+++ b/test/comparison-tests/localTsImplementationOfTypings/expectedOutput-2.4/output.txt
@@ -1,0 +1,5 @@
+    Asset     Size  Chunks             Chunk Names
+bundle.js  2.98 kB       0  [emitted]  main
+chunk    {0} bundle.js (main) 234 bytes [entry] [rendered]
+    [0] ./.test/localTsImplementationOfTypings/fake.ts 133 bytes {0} [built]
+    [1] ./.test/localTsImplementationOfTypings/app.ts 101 bytes {0} [built]

--- a/test/comparison-tests/localTsImplementationOfTypings/fake.ts
+++ b/test/comparison-tests/localTsImplementationOfTypings/fake.ts
@@ -1,0 +1,3 @@
+export function sayHello(name: string): string {
+    return `Hello, ${name}!`;
+}

--- a/test/comparison-tests/localTsImplementationOfTypings/tsconfig.json
+++ b/test/comparison-tests/localTsImplementationOfTypings/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"compilerOptions": {
+		
+	},
+	"include": [
+		"app.ts"
+	]
+}

--- a/test/comparison-tests/localTsImplementationOfTypings/webpack.config.js
+++ b/test/comparison-tests/localTsImplementationOfTypings/webpack.config.js
@@ -1,0 +1,21 @@
+var path = require('path');
+
+module.exports = {
+    entry: './app.ts',
+    output: {
+        filename: 'bundle.js'
+    },
+    resolve: {
+        alias: {
+            api: path.resolve(__dirname, 'fake')
+        },
+        extensions: ['.ts', '.js']
+    },
+    module: {
+        rules: [
+            { test: /\.ts$/, loader: 'ts-loader' }
+        ]
+    }
+}
+
+


### PR DESCRIPTION
Fixes #620 by only reusing Typscript's isExternalLibraryImport designation if the loader-resolved module is a JS file and not a TS file.

Added a comparison-test rather than an execution-test as this really is just a question of "does it compile" rather than changing any behavior related to the generated JS.

Note that this also locks typescript down to 2.4.2 because right now building from a clean clone fails. Since typescript is currently ^2.4.0 it upgraded locally to the latest - 2.5.2 - and since 2.5.x updates some general typings (in this case System.readFile) that causes a build failure in config.ts. Not sure how you guys want to deal with that - it seemed outside the scope of my change to fix that but it did look fairly simple.

Please let me know what you're thinking!

-Will