### PR TITLE
Fix default logLevel in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Provide custom transformers - only compatible with TypeScript 2.3+ (and 2.4 if u
 This is important if you read from stdout or stderr and for proper error handling.
 The default value ensures that you can read from stdout e.g. via pipes or you use webpack -j to generate json output.
 
-#### logLevel *(string) (default=info)*
+#### logLevel *(string) (default=warn)*
 
 Can be `info`, `warn` or `error` which limits the log output to the specified log level.
 Beware of the fact that errors are written to stderr and everything else is written to stderr (or stdout if logInfoToStdOut is true).


### PR DESCRIPTION
Looks like this was missed in #643.