### PR TITLE
bug fix with appendTsxSuffixTo for vue lang=tsx

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,10 @@ function getLoaderOptions(loader: Webpack) {
     const instanceName = webpackIndex + '_' + (loaderOptions.instance || configFileOptions.instance || 'default');
 
     if (hasOwnProperty(loaderOptionsCache, instanceName)) {
+        // bypass the cache
+        let {appendTsSuffixTo=[], appendTsxSuffixTo=[]} = loaderOptions
+        Object.assign(loaderOptionsCache[instanceName], {appendTsSuffixTo, appendTsxSuffixTo})
+        
         return loaderOptionsCache[instanceName];
     }
 


### PR DESCRIPTION
When using <script lang="tsx">, appendTsxSuffixTo is not work, this PR fixes it.

Hello there.

Reference on **Vue JSX integration not working.** #638 
@HerringtonDarkholme @wbijker @johnnyreilly @vhqtvn 

I was supposed to write tsx in a single `*.vue` file, with `<script lang="tsx">`, but I tried the code in docs and failed. So I tracked source code from `webpack`, `vue-loader`, `ts-loader` for whole day, and found a way to resolve it.

And I transfomed a repo for demo [here](https://github.com/Plasmatium/vue-plc-ts), you can test it.
Running screenshot as below:
![image](https://user-images.githubusercontent.com/13704796/33561734-70910542-d94e-11e7-9fe7-13180b0b3996.png)

in vue-loader, should config as below:
```javascript
// suppose vueLoaderConfig is already exist as a vue-loader config
vueLoaderConfig.loaders.tsx = [
  'babel-loader',
  {
    loader: 'ts-loader',
    options: {
      appendTsxSuffixTo: [/\.vue$/]
    }
  }
]
```
in rules:
```javascript
// ...
    {
        test: /\.tsx?$/,
        use: [
          {
            loader: 'babel-loader'
          },
          {
            loader: 'ts-loader',
            options: {
              // DO NOT append anything here
            }
          }
        ],
        exclude: /node_modules/
      },
// ...
```
and the **most important**, you should bypass the `loaderOptionCache` for the `appendTsxSuffixTo` in node_modules/ts-loader/index.js, source [here](https://github.com/Plasmatium/vue-plc-ts/blob/master/node_modules/ts-loader/dist/index.js) in line 65-66 for detials

But in VS Code, its intellisense looks like running with some bugs, and I need help.

[Demo repo here](https://github.com/Plasmatium/vue-plc-ts)