### PR TITLE
Fixes to support builder api for compiling https://github.com/johnnyreilly/typescript-ts-loader-watch-api-illustration correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,7 +201,7 @@ function updateFileInCache(filePath: string, contents: string, instance: TSInsta
         file.text = contents;
         instance.version!++;
         if (instance.watchHost && fileWatcherEventKind === undefined) {
-            instance.watchHost.invokeFileWatcher(filePath, instance.compiler.FileWatcherEventKind.Changed);
+            fileWatcherEventKind = instance.compiler.FileWatcherEventKind.Changed;
         }
     }
 

--- a/src/servicesHost.ts
+++ b/src/servicesHost.ts
@@ -179,7 +179,7 @@ export function makeWatchHost(
         useCaseSensitiveFileNames: () => compiler.sys.useCaseSensitiveFileNames,
         getNewLine: () => newLine,
         getCurrentDirectory,
-        getDefaultLibFileName,
+        getDefaultLibFileName: options => compiler.getDefaultLibFilePath(options),
 
         fileExists,
         readFile: readFileWithCachingText,
@@ -208,10 +208,6 @@ export function makeWatchHost(
         createProgram: compiler.createAbstractBuilder
     };
     return watchHost;
-
-    function getDefaultLibFileName(options: typescript.CompilerOptions) {
-        return path.join(path.dirname(compiler.sys.getExecutingFilePath()), compiler.getDefaultLibFileName(options));
-    }
 
     function getRootFileNames() {
         return Object.keys(files).filter(filePath => filePath.match(scriptRegex));


### PR DESCRIPTION
With this the error reporting happens correctly.