### PR TITLE
Initial implementation of trace for traceResolution in #691

### DIFF
--- a/src/servicesHost.ts
+++ b/src/servicesHost.ts
@@ -109,6 +109,7 @@ export function makeServicesHost(
         getCompilationSettings: () => compilerOptions,
         getDefaultLibFileName: (options: typescript.CompilerOptions) => compiler.getDefaultLibFilePath(options),
         getNewLine: () => newLine,
+        trace: log.log,
         log: log.log,
 
         /* Unclear if this is useful


### PR DESCRIPTION
Hi,

sorry for the long time between the initial discussion and the pull request. I tried to do the first implementation for issue #691 

I tried to write a test but could not. When running them it gets stuck at the first test:

```
Uncaught AssertionError [ERR_ASSERTION]: patch0/output.txt is different between actual and expected
      + expected - actual

           Asset     Size  Chunks             Chunk Names
       bundle.js   A-NUMBER-OF kB       0  [emitted]  main
      -   [0] ./.test/aliasResolution/app.ts A-NUMBER-OF bytes {0} [built]
      +   [0] ./.test/aliasResolution/app.ts A-NUMBER-OF bytes {0}
          [1] ./.test/aliasResolution/common/components/myComponent.ts A-NUMBER-OF bytes {0} [built]
```