### PR TITLE
Add note in docs about external config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,9 @@ You may provide
 * a relative path to the configuration file. It will be resolved relative to the respective `.ts` entry file.
 * an absolute path to the configuration file.
 
+Please note, that if the configuration file is outside of your project directory, you might need to set the `context` option to avoid TypeScript issues (like TS18003).
+In this case the `configFile` should point to the `tsconfig.json` and `context` to the project root.
+
 #### colors _(boolean) (default=true)_
 
 If `false`, disables built-in colors in logger messages.


### PR DESCRIPTION
Documents and fixes #732

Just a small note that if your `tsconfig.json` is outside of your project (root), TypeScript behaves weird and throws errors, if you don't also set the `context` to the project root.