### PR TITLE
Remove cross-env from react-hot-boilerplate

### DIFF
--- a/examples/react-hot-boilerplate/package.json
+++ b/examples/react-hot-boilerplate/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "webpack-dev-server --mode development",
     "prebuild": "rimraf dist",
-    "build": "cross-env webpack --mode production --config webpack.config.production.js",
+    "build": "webpack --mode production --config webpack.config.production.js",
     "postbuild": "copyfiles index.html dist"
   },
   "repository": {
@@ -34,7 +34,6 @@
     "@types/react-dom": "^16.0.0",
     "@types/react-hot-loader": "^3.0.4",
     "copyfiles": "^1.2.0",
-    "cross-env": "^3.1.4",
     "fork-ts-checker-webpack-plugin": "^0.4.0",
     "react-hot-loader": "^3.0.0",
     "rimraf": "^2.6.0",


### PR DESCRIPTION
With the [upgrade to Webpack 4](https://github.com/TypeStrong/ts-loader/commit/c122c9ffbf24eca99ef9297e9241d6176542010d), passing `NODE_ENV` is no longer necessary, and neither  is the `cross-env` dependency. 

Removing `cross-env` as suggested in https://github.com/TypeStrong/ts-loader/commit/c122c9ffbf24eca99ef9297e9241d6176542010d#r27961370.