### PR TITLE
Pass `context' to error formatters

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,6 +14,7 @@ export interface ErrorInfo {
   file: string;
   line: number;
   character: number;
+  context: string;
 }
 
 export interface AsyncCallback {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ export function formatErrors(
             file === undefined
               ? undefined
               : file.getLineAndCharacterOfPosition(diagnostic.start!);
-          const errorInfo = {
+          const errorInfo: ErrorInfo = {
             code: diagnostic.code,
             severity: compiler.DiagnosticCategory[
               diagnostic.category
@@ -84,7 +84,8 @@ export function formatErrors(
             ),
             file: file === undefined ? '' : path.normalize(file.fileName),
             line: position === undefined ? 0 : position.line + 1,
-            character: position === undefined ? 0 : position.character + 1
+            character: position === undefined ? 0 : position.character + 1,
+            context
           };
 
           const message =


### PR DESCRIPTION
This PR adds the `context` variable to the `ErrorInfo` interface. The primary use case is here is to allow custom error formatters to recover the full path to the file in which an error occurred, since I wanted to read the file from disk to use `'babel-code-frame'` to go along with the message.

I couldn't find tests that exercise `errorFormatter` functionality, but I'm happy to write some extras if you'd like.