### PR TITLE
fix(index.js): create only one instance per-build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,14 @@ import {
   TSFile,
   TSInstance,
   Webpack,
+  WebpackError,
   LogLevel
 } from './interfaces';
 
 const webpackInstances: Compiler[] = [];
 const loaderOptionsCache: LoaderOptionsCache = {};
+
+let instanceOrError: { instance?: TSInstance; error?: WebpackError };
 
 /**
  * The entry point for ts-loader
@@ -26,7 +29,8 @@ function loader(this: Webpack, contents: string) {
   this.cacheable && this.cacheable();
   const callback = this.async();
   const options = getLoaderOptions(this);
-  const instanceOrError = getTypeScriptInstance(options, this);
+
+  instanceOrError = instanceOrError || getTypeScriptInstance(options, this);
 
   if (instanceOrError.error !== undefined) {
     callback(instanceOrError.error);


### PR DESCRIPTION
The idea behind the PR is to create only one TypeScript instance.

The loader is imported/required by webpack only once, so we can initialize and keep only one instance of TypeScript instead of creating an instance for every file that needs to be transpiled.

This will have an effect on improving build time after the first file/source that passes through the loader that initializes the instance of TS.