### PR TITLE
Fix options caching when ts-loader is used in multiple rules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,15 +117,21 @@ function getLoaderOptions(loader: Webpack) {
   const instanceName =
     webpackIndex + '_' + (loaderOptions.instance || 'default');
 
-  if (loaderOptionsCache.hasOwnProperty(instanceName)) {
-    return loaderOptionsCache[instanceName];
+  if (!loaderOptionsCache.hasOwnProperty(instanceName)) {
+    loaderOptionsCache[instanceName] = new WeakMap();
+  }
+
+  const cache = loaderOptionsCache[instanceName];
+
+  if (cache.has(loaderOptions)) {
+    return cache.get(loaderOptions) as LoaderOptions;
   }
 
   validateLoaderOptions(loaderOptions);
 
   const options = makeLoaderOptions(instanceName, loaderOptions);
 
-  loaderOptionsCache[instanceName] = options;
+  cache.set(loaderOptions, options);
 
   return options;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -258,7 +258,7 @@ export interface TSInstance {
 }
 
 export interface LoaderOptionsCache {
-  [name: string]: LoaderOptions;
+  [name: string]: WeakMap<LoaderOptions, LoaderOptions>;
 }
 
 export interface TSInstances {

--- a/test/execution-tests/optionsCaching/foo.ts
+++ b/test/execution-tests/optionsCaching/foo.ts
@@ -1,0 +1,1 @@
+import './foo.vue'

--- a/test/execution-tests/optionsCaching/foo.vue
+++ b/test/execution-tests/optionsCaching/foo.vue
@@ -1,0 +1,7 @@
+const React = {}
+
+export default {
+  render () {
+    return <div>hello</div>
+  }
+}

--- a/test/execution-tests/optionsCaching/tsconfig.json
+++ b/test/execution-tests/optionsCaching/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"compilerOptions": {
+    "target": "esnext",
+    "jsx": "react"
+  }
+}

--- a/test/execution-tests/optionsCaching/webpack.config.js
+++ b/test/execution-tests/optionsCaching/webpack.config.js
@@ -1,0 +1,25 @@
+var path = require('path')
+
+module.exports = {
+    mode: 'development',
+    entry: path.resolve(__dirname, 'foo.ts'),
+    output: {
+        path: __dirname,
+        filename: 'bundle.js'
+    },
+    module: {
+        rules: [
+            { test: /\.ts$/, loader: 'ts-loader', options: {} },
+            {
+                test: /\.vue$/,
+                loader: 'ts-loader',
+                options: {
+                    appendTsxSuffixTo: [/\.vue$/]
+                }
+            }
+        ]
+    }
+}
+
+// for test harness purposes only, you would not need this in a normal project
+module.exports.resolveLoader = { alias: { 'ts-loader': require('path').join(__dirname, "../../../index.js") } }


### PR DESCRIPTION
This is a bug we discovered in latest Vue CLI 3 beta (ref: https://github.com/vuejs/vue-cli/issues/1399).

When the webpack config contains multiple rules that use `ts-loader` but with different options, the current option caching implementation will incorrectly always use the cached options from the first matched rule. This is because the caching is done by using only the webpack instance + the `instance` option as the key - it's not taking multiple rules into account.

This PR fixes it by ensuring each webpack instance + ts instance combo gets its own cache which caches validated options using a WeakMap.

The added test would fail without this fix as the options in the second rule will be ignored and `appendTsxSuffixTo` will take no effect.