### PR TITLE
fix(types): expose public interfaces from root index.d.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -391,3 +391,10 @@ function makeSourceMap(
 }
 
 export = loader;
+
+/**
+ * expose public types via declaration merging
+ */
+namespace loader {
+  export interface Options extends LoaderOptions {}
+}


### PR DESCRIPTION
this tweaks https://github.com/TypeStrong/ts-loader/pull/788 by exposing proper public types API from root index.d.ts so consumer doesn't have to traverse private package path to access interfaces.

**before**

```js
// @ts-check
const tsLoaderOptionsRules = /** @type {import('ts-loader/dist/types/interfaces').LoaderOptions}*/ ({
  configFile: tsConfig,
  transpileOnly: true
})
```

**after**

```js
// @ts-check
const tsLoaderOptionsRules = /** @type {import('ts-loader').Options}*/ ({
  configFile: tsConfig,
  transpileOnly: true
})
```