### PR TITLE
fix(loader): new Error to webpack when errors occured in the loader f…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ function loader(this: Webpack, contents: string) {
   const instanceOrError = getTypeScriptInstance(options, this);
 
   if (instanceOrError.error !== undefined) {
-    callback(instanceOrError.error);
+    callback(new Error(instanceOrError.error.message));
     return;
   }
 


### PR DESCRIPTION
…unction

When using `callback(instanceOrError.error)` to throw error, webpack will print :

```
NonErrorEmittedError: (Emitted value instead of an instance of Error) [object Object]
    at runLoaders (/Users/linxiaowu/SourceCode/eno/node_modules/webpack/lib/NormalModule.js:300:13)
    at /Users/linxiaowu/SourceCode/eno/node_modules/loader-runner/lib/LoaderRunner.js:364:11
    at /Users/linxiaowu/SourceCode/eno/node_modules/loader-runner/lib/LoaderRunner.js:230:18
    at context.callback (/Users/linxiaowu/SourceCode/eno/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at Object.loader (/Users/linxiaowu/SourceCode/eno/node_modules/ts-loader/dist/index.js:19:9)
```

This way can not show the error message explicitly. So I change the returning value when error.

`new Error(instanceOrError.error.message)`