### PR TITLE
Fixed issue with incorrect output path for declaration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.0
+
+* [feat: Fixed issue with incorrect output path for declaration files](https://github.com/TypeStrong/ts-loader/pull/822) - thanks @JonWallsten! **BREAKING CHANGE**
+
 ## 4.5.0
 
 * [feat: Added support for TypeScript declaration map](https://github.com/TypeStrong/ts-loader/pull/821) - thanks @JonWallsten!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "4.5.0",
+  "version": "5.0.0",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist/types/index.d.ts",

--- a/src/after-compile.ts
+++ b/src/after-compile.ts
@@ -251,7 +251,7 @@ function provideDeclarationFilesToWebpack(
 
     declarationFiles.forEach(declarationFile => {
       const assetPath = path.relative(
-        compilation.compiler.context,
+        compilation.compiler.outputPath,
         declarationFile.name
       );
       compilation.assets[assetPath] = {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -149,6 +149,7 @@ export interface WebpackCompilation {
 export interface WebpackCompiler {
   isChild(): boolean;
   context: string; // a guess
+  outputPath: string;
   watchFileSystem: WebpackNodeWatchFileSystem;
   /** key is filepath and value is Date as a number */
   fileTimestamps: Map<string, number>;

--- a/test/comparison-tests/declarationOutput/expectedOutput-3.0/output.txt
+++ b/test/comparison-tests/declarationOutput/expectedOutput-3.0/output.txt
@@ -1,7 +1,7 @@
-                Asset       Size  Chunks             Chunk Names
-            bundle.js   5.13 KiB    main  [emitted]  main
-    ../types/app.d.ts  110 bytes          [emitted]  
-../types/sub/dep.d.ts   63 bytes          [emitted]  
+       Asset       Size  Chunks             Chunk Names
+   bundle.js   5.13 KiB    main  [emitted]  main
+    app.d.ts  110 bytes          [emitted]  
+sub/dep.d.ts   63 bytes          [emitted]  
 Entrypoint main = bundle.js
 [./app.ts] 910 bytes {main} [built]
 [./sub/dep.ts] 182 bytes {main} [built]

--- a/test/comparison-tests/declarationOutput/expectedOutput-3.0/output.txt
+++ b/test/comparison-tests/declarationOutput/expectedOutput-3.0/output.txt
@@ -1,7 +1,7 @@
-       Asset       Size  Chunks             Chunk Names
-   bundle.js   5.13 KiB    main  [emitted]  main
-    app.d.ts  110 bytes          [emitted]  
-sub/dep.d.ts   63 bytes          [emitted]  
+                Asset       Size  Chunks             Chunk Names
+            bundle.js   5.13 KiB    main  [emitted]  main
+    ../types/app.d.ts  110 bytes          [emitted]  
+../types/sub/dep.d.ts   63 bytes          [emitted]  
 Entrypoint main = bundle.js
 [./app.ts] 910 bytes {main} [built]
 [./sub/dep.ts] 182 bytes {main} [built]

--- a/test/comparison-tests/declarationOutput/tsconfig.json
+++ b/test/comparison-tests/declarationOutput/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
-		"declaration": true
+		"declaration": true,
+    	"declarationDir": "types"
 	}
 }

--- a/test/comparison-tests/declarationOutput/tsconfig.json
+++ b/test/comparison-tests/declarationOutput/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
 		"declaration": true,
-    	"declarationDir": "types"
+		"declarationDir": ".output"
 	}
 }

--- a/test/comparison-tests/declarationOutputWithMaps/expectedOutput-3.0/app.d.ts.map
+++ b/test/comparison-tests/declarationOutputWithMaps/expectedOutput-3.0/app.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"app.d.ts","sourceRoot":"","sources":["app.ts"],"names":[],"mappings":"AAAA,OAAO,GAAG,GAAG,QAAQ,WAAW,CAAC,CAAC;AAElC,cAAM,IAAK,SAAQ,GAAG;IACrB,WAAW;CAGX;AAED,SAAS,IAAI,CAAC"}
+{"version":3,"file":"app.d.ts","sourceRoot":"","sources":["../app.ts"],"names":[],"mappings":"AAAA,OAAO,GAAG,GAAG,QAAQ,WAAW,CAAC,CAAC;AAElC,cAAM,IAAK,SAAQ,GAAG;IACrB,WAAW;CAGX;AAED,SAAS,IAAI,CAAC"}

--- a/test/comparison-tests/declarationOutputWithMaps/expectedOutput-3.0/output.txt
+++ b/test/comparison-tests/declarationOutputWithMaps/expectedOutput-3.0/output.txt
@@ -1,9 +1,9 @@
-           Asset       Size  Chunks             Chunk Names
-       bundle.js   5.13 KiB    main  [emitted]  main
-    app.d.ts.map  194 bytes          [emitted]  
-        app.d.ts  143 bytes          [emitted]  
-sub/dep.d.ts.map  142 bytes          [emitted]  
-    sub/dep.d.ts   96 bytes          [emitted]  
+                    Asset       Size  Chunks             Chunk Names
+                bundle.js   5.13 KiB    main  [emitted]  main
+    ../types/app.d.ts.map  197 bytes          [emitted]  
+        ../types/app.d.ts  143 bytes          [emitted]  
+../types/sub/dep.d.ts.map  152 bytes          [emitted]  
+    ../types/sub/dep.d.ts   96 bytes          [emitted]  
 Entrypoint main = bundle.js
 [./app.ts] 910 bytes {main} [built]
 [./sub/dep.ts] 182 bytes {main} [built]

--- a/test/comparison-tests/declarationOutputWithMaps/expectedOutput-3.0/output.txt
+++ b/test/comparison-tests/declarationOutputWithMaps/expectedOutput-3.0/output.txt
@@ -1,9 +1,9 @@
-                    Asset       Size  Chunks             Chunk Names
-                bundle.js   5.13 KiB    main  [emitted]  main
-    ../types/app.d.ts.map  197 bytes          [emitted]  
-        ../types/app.d.ts  143 bytes          [emitted]  
-../types/sub/dep.d.ts.map  152 bytes          [emitted]  
-    ../types/sub/dep.d.ts   96 bytes          [emitted]  
+           Asset       Size  Chunks             Chunk Names
+       bundle.js   5.13 KiB    main  [emitted]  main
+    app.d.ts.map  197 bytes          [emitted]  
+        app.d.ts  143 bytes          [emitted]  
+sub/dep.d.ts.map  152 bytes          [emitted]  
+    sub/dep.d.ts   96 bytes          [emitted]  
 Entrypoint main = bundle.js
 [./app.ts] 910 bytes {main} [built]
 [./sub/dep.ts] 182 bytes {main} [built]

--- a/test/comparison-tests/declarationOutputWithMaps/expectedOutput-3.0/sub/dep.d.ts.map
+++ b/test/comparison-tests/declarationOutputWithMaps/expectedOutput-3.0/sub/dep.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"dep.d.ts","sourceRoot":"","sources":["dep.ts"],"names":[],"mappings":"AACA,cAAM,IAAI;IACT,WAAW;CAGX;AAED,SAAS,IAAI,CAAC"}
+{"version":3,"file":"dep.d.ts","sourceRoot":"","sources":["../../sub/dep.ts"],"names":[],"mappings":"AACA,cAAM,IAAI;IACT,WAAW;CAGX;AAED,SAAS,IAAI,CAAC"}

--- a/test/comparison-tests/declarationOutputWithMaps/tsconfig.json
+++ b/test/comparison-tests/declarationOutputWithMaps/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
 		"declaration": true,
-		"declarationMap": true
+		"declarationMap": true,
+		"declarationDir": "types"
 	}
 }

--- a/test/comparison-tests/declarationOutputWithMaps/tsconfig.json
+++ b/test/comparison-tests/declarationOutputWithMaps/tsconfig.json
@@ -2,6 +2,6 @@
 	"compilerOptions": {
 		"declaration": true,
 		"declarationMap": true,
-		"declarationDir": "types"
+		"declarationDir": ".output"
 	}
 }


### PR DESCRIPTION
In regards of: https://github.com/TypeStrong/ts-loader/issues/190

I'll try to explain the fix:
Below is the code where we prepare the relative path for the d.ts files so we can add them to Webpack's compilation assets. 
```
const assetPath = path.relative(
        compilation.compiler.context,
        declarationFile.name
      );
compilation.assets[assetPath] = {
        source: () => declarationFile.text,
        size: () => declarationFile.text.length
      };
```
**Example**
Project root: /home/user/jon/projects/a/
[webpack.main]: index.ts
[webpack.output.path]: /home/user/jon/projects/a/dist/
[compilerOptions.declarationDir]: ./dist/typings/

[Scope variables]
[compilation.compiler.context]: /home/user/jon/projects/a/
[compilation.compiler.outputPath]: /home/user/jon/projects/a/dist/

[Other]
All relative assets in [compilation.assets] will have [compilation.compiler.outputPath] as base it seems.

**Results**
What will happen here is that `path.relative` will return a relative path with **compiler.context** (project root) as a base. So when TypeScript compiler outputs **/home/user/jon/projects/a/dist/index.d.ts** (declarationDir is relative to the project root), `path.relative` will strip the project root and we will end up with **dist/index.d.ts**. It looks correct, right? Well, if we would store the compiled files relative to the project root it would. The issue is that compilation.assets seems to equal webpack.output.path.
So we'll end up with this:
```
/home/user/jon/projects/a/dist/index.js
/home/user/jon/projects/a/dist/dist/index.d.ts
```
By changing `compilation.compiler.context` -> `compilation.compiler.outputPath` we will get a path relative to the output folder  instead.

So if we have  the same output from the TypeScript compiler: **/home/user/jon/projects/a/dist/index.d.ts** and we strip away **/home/user/jon/projects/a/dist/** instead, we end up with **index.d.ts**. The result would be:
```
/home/user/jon/projects/a/dist/index.js
/home/user/jon/projects/a/dist/index.d.ts
```

Note that this might be a breaking change since people probably has workarounds or have adapted to this way. Myself included.