### PR TITLE
Lists typescript as a peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.2.1
+
+* [feat: Lists typescript as a peer dependency](https://github.com/TypeStrong/ts-loader/pull/841) - thanks @arcanis!
+
 ## 5.2.0
 
 * [feat: Initial support for project references - `projectReferences`](https://github.com/TypeStrong/ts-loader/pull/817) - thanks @andrewbranch!

--- a/package.json
+++ b/package.json
@@ -84,5 +84,8 @@
     "typescript": "^3.0.1",
     "webpack": "^4.5.0",
     "webpack-cli": "^2.1.2"
+  },
+  "peerDependencies": {
+    "typescript": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist/types/index.d.ts",


### PR DESCRIPTION
> `ts-loader` currently relies on the hoisting in order to have access to the `typescript` package

> It causes issues with package trees that do not support hoisting, such as Yarn Plug'n'Play.

Should fix #839 😃 