### PR TITLE
Fix projectReferences with rootDir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.3.1
+
+* [fix: projectReferences with rootDir](https://github.com/TypeStrong/ts-loader/pull/871) (#868) - thanks @andrewbranch!
+
 ## v5.3.0
 
 * [feat: Exposes a `resolveNodeModule` option](https://github.com/TypeStrong/ts-loader/pull/862) - thanks @arcanis!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist/types/index.d.ts",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -386,7 +386,8 @@ function getOutputJavaScriptFileName(
   projectReference: typescript.ResolvedProjectReference
 ) {
   const { options } = projectReference.commandLine;
-  const projectDirectory = path.dirname(projectReference.sourceFile.fileName);
+  const projectDirectory =
+    options.rootDir || path.dirname(projectReference.sourceFile.fileName);
   const relativePath = path.relative(projectDirectory, inputFileName);
   const outputPath = path.resolve(
     options.outDir || projectDirectory,

--- a/test/comparison-tests/projectReferencesRootDir/app.ts
+++ b/test/comparison-tests/projectReferencesRootDir/app.ts
@@ -1,0 +1,3 @@
+import { lib } from './lib/src/index';
+
+console.log(lib.one, lib.two, lib.three);

--- a/test/comparison-tests/projectReferencesRootDir/expectedOutput-3.1/bundle.js
+++ b/test/comparison-tests/projectReferencesRootDir/expectedOutput-3.1/bundle.js
@@ -1,0 +1,113 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony import */ var _lib_src_index__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./lib/src/index */ \"./lib/src/index.ts\");\n\nconsole.log(_lib_src_index__WEBPACK_IMPORTED_MODULE_0__[\"lib\"].one, _lib_src_index__WEBPACK_IMPORTED_MODULE_0__[\"lib\"].two, _lib_src_index__WEBPACK_IMPORTED_MODULE_0__[\"lib\"].three);\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ }),
+
+/***/ "./lib/src/index.ts":
+/*!**************************!*\
+  !*** ./lib/src/index.ts ***!
+  \**************************/
+/*! exports provided: lib */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \"lib\", function() { return lib; });\nconst lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///./lib/src/index.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesRootDir/expectedOutput-3.1/bundle.js
+++ b/test/comparison-tests/projectReferencesRootDir/expectedOutput-3.1/bundle.js
@@ -106,7 +106,7 @@ eval("__webpack_require__.r(__webpack_exports__);\n/* harmony import */ var _lib
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \"lib\", function() { return lib; });\nconst lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///./lib/src/index.ts?");
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \"lib\", function() { return lib; });\nconst lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n//# sourceMappingURL=index.js.map\n\n//# sourceURL=webpack:///./lib/src/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesRootDir/expectedOutput-3.1/output.txt
+++ b/test/comparison-tests/projectReferencesRootDir/expectedOutput-3.1/output.txt
@@ -1,0 +1,5 @@
+    Asset      Size  Chunks             Chunk Names
+bundle.js  4.65 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[./app.ts] 81 bytes {main} [built]
+[./lib/src/index.ts] 61 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesRootDir/expectedOutput-3.1/output.txt
+++ b/test/comparison-tests/projectReferencesRootDir/expectedOutput-3.1/output.txt
@@ -1,5 +1,10 @@
     Asset      Size  Chunks             Chunk Names
-bundle.js  4.65 KiB    main  [emitted]  main
+bundle.js  4.69 KiB    main  [emitted]  main
 Entrypoint main = bundle.js
 [./app.ts] 81 bytes {main} [built]
-[./lib/src/index.ts] 61 bytes {main} [built]
+[./lib/src/index.ts] 94 bytes {main} [built] [1 warning]
+
+WARNING in ./lib/src/index.ts
+Module Warning (from /index.js):
+Could not find source map file for referenced project output lib\out\index.js. Ensure the 'sourceMap' compiler option is enabled in lib\tsconfig.json to ensure Webpack can map project references to the appropriate source files.
+ @ ./app.ts 1:0-38 2:12-15 2:21-24 2:30-33

--- a/test/comparison-tests/projectReferencesRootDir/lib/out/index.d.ts
+++ b/test/comparison-tests/projectReferencesRootDir/lib/out/index.d.ts
@@ -1,0 +1,5 @@
+export declare const lib: {
+    one: number;
+    two: number;
+    three: number;
+};

--- a/test/comparison-tests/projectReferencesRootDir/lib/out/index.js
+++ b/test/comparison-tests/projectReferencesRootDir/lib/out/index.js
@@ -1,0 +1,6 @@
+export const lib = {
+    one: 1,
+    two: 2,
+    three: 3
+};
+//# sourceMappingURL=index.js.map

--- a/test/comparison-tests/projectReferencesRootDir/lib/src/index.ts
+++ b/test/comparison-tests/projectReferencesRootDir/lib/src/index.ts
@@ -1,0 +1,5 @@
+export const lib = {
+  one: 1,
+  two: 2,
+  three: 3
+};

--- a/test/comparison-tests/projectReferencesRootDir/lib/tsconfig.json
+++ b/test/comparison-tests/projectReferencesRootDir/lib/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "composite": true,
+    "sourceMap": true,
+    "outDir": "./out",
+    "rootDir": "./src"
+  },
+  "files": [
+    "./src/index.ts"
+  ]
+}

--- a/test/comparison-tests/projectReferencesRootDir/tsconfig.json
+++ b/test/comparison-tests/projectReferencesRootDir/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+  },
+  "references": [
+    { "path": "./lib" }
+  ]
+}

--- a/test/comparison-tests/projectReferencesRootDir/webpack.config.js
+++ b/test/comparison-tests/projectReferencesRootDir/webpack.config.js
@@ -1,0 +1,19 @@
+var path = require('path')
+
+module.exports = {
+    mode: 'development',
+    entry: './app.ts',
+    output: {
+        filename: 'bundle.js'
+    },
+    resolve: {
+        extensions: ['.ts', '.js']
+    },
+    module: {
+        rules: [
+            { test: /\.ts$/, loader: 'ts-loader', options: { projectReferences: true } }
+        ]
+    }
+}
+
+


### PR DESCRIPTION
`rootDir` inside a referenced project’s config wasn’t being considered in figuring out where the output JS files for the project will be, a.k.a. why https://github.com/Microsoft/TypeScript/issues/26410 should still be a thing 🙂 

Fixes #868 
