### PR TITLE
run the tests with node11 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "11"
 sudo: required
 install:
   - yarn install


### PR DESCRIPTION
Right now the node 11 is an active release (https://github.com/nodejs/Release#release-schedule), so let's run the ts-loader tests on that version as well :)
