### PR TITLE
Pass ts.Program to getCustomTransformers()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.3.3
+
+* [fix: Pass ts.Program to getCustomTransformers](https://github.com/TypeStrong/ts-loader/pull/889) (#860) - thanks @andersekdahl!
+
 ## v5.3.2
 
 * [feat: enable experimentalFileCaching by default](https://github.com/TypeStrong/ts-loader/pull/885) (#868) - thanks @timocov!

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ This will ensure that the plugin checks for both syntactic errors (eg `const arr
 
 Also, if you are using `thread-loader` in watch mode, remember to set `poolTimeout: Infinity` so workers don't die.
 
-#### getCustomTransformers _( () => { before?: TransformerFactory<SourceFile>[]; after?: TransformerFactory<SourceFile>[]; } )_
+#### getCustomTransformers _( (program: Program) => { before?: TransformerFactory<SourceFile>[]; after?: TransformerFactory<SourceFile>[]; } )_
 
 Provide custom transformers - only compatible with TypeScript 2.3+ (and 2.4 if using `transpileOnly` mode). For example usage take a look at [typescript-plugin-styled-components](https://github.com/Igorbek/typescript-plugin-styled-components) or our [test](test/comparison-tests/customTransformer).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist/types/index.d.ts",

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -188,7 +188,7 @@ function successfulTypeScriptInstance(
       program,
       dependencyGraph: {},
       reverseDependencyGraph: {},
-      transformers: getCustomTransformers(),
+      transformers: getCustomTransformers(program),
       colors
     };
 
@@ -235,7 +235,7 @@ function successfulTypeScriptInstance(
     otherFiles,
     languageService: null,
     version: 0,
-    transformers: getCustomTransformers(),
+    transformers: {} as typescript.CustomTransformers, // this is only set temporarily, custom transformers are created further down
     dependencyGraph: {},
     reverseDependencyGraph: {},
     modifiedFiles: null,
@@ -267,6 +267,8 @@ function successfulTypeScriptInstance(
     instance.program = instance.watchOfFilesAndCompilerOptions
       .getProgram()
       .getProgram();
+
+    instance.transformers = getCustomTransformers(instance.program);
   } else {
     const servicesHost = makeServicesHost(
       scriptRegex,
@@ -285,6 +287,8 @@ function successfulTypeScriptInstance(
     if (servicesHost.clearCache !== null) {
       loader._compiler.hooks.watchRun.tap('ts-loader', servicesHost.clearCache);
     }
+
+    instance.transformers = getCustomTransformers(instance.languageService!.getProgram());
   }
 
   loader._compiler.hooks.afterCompile.tapAsync(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -330,7 +330,7 @@ export interface LoaderOptions {
   happyPackMode: boolean;
   getCustomTransformers?:
     | string
-    | (() => typescript.CustomTransformers | undefined);
+    | ((program: typescript.Program) => typescript.CustomTransformers | undefined);
   experimentalWatchApi: boolean;
   allowTsInNodeModules: boolean;
   experimentalFileCaching: boolean;

--- a/test/comparison-tests/customTransformer/webpack.config.js
+++ b/test/comparison-tests/customTransformer/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
                 test: /\.ts$/,
                 loader: 'ts-loader',
                 options: {
-                    getCustomTransformers: () => ({
+                    getCustomTransformers: (program) => ({
                         before: [uppercaseStringLiteralTransformer]
                     })
                 }

--- a/test/comparison-tests/customTransformerUsingPathString/customerTransformers.js
+++ b/test/comparison-tests/customTransformerUsingPathString/customerTransformers.js
@@ -1,5 +1,5 @@
 var uppercaseStringLiteralTransformer = require('./uppercaseStringLiteralTransformer').default;
 
-module.exports = () => ({
+module.exports = (program) => ({
   before: [uppercaseStringLiteralTransformer]
 });


### PR DESCRIPTION
A lot of transformers requires a Program instance so we pass ts.Program to getCustomTransformers() to be able to pass it on to transformers. Transformers mostly need ts.Program in order to access the type checker.

Fixes #860