### PR TITLE
release event not available so use push event and filter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+.vscode
+.test
+node_modules
+examples

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,6 +1,7 @@
 workflow "build, test and publish on release" {
   on = "push"
-  resolves = "publish"
+#  resolves = "publish" - commented until this issue is resolved: https://github.com/actions/bin/issues/13
+  resolves = "check for new tag"
 }
 
 # install with yarn

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -9,7 +9,7 @@ action "install" {
   runs = "yarn"
   args = "install"
   env = {
-    GITHUB_WORKSPACE  = "/github/workspace/ts-loader"
+    GITHUB_WORKSPACE = "/github/workspace/ts-loader"
   }
 }
 
@@ -19,9 +19,6 @@ action "build" {
   uses = "actions/npm@1.0.0"
   runs = "yarn"
   args = "build"
-  env = {
-    GITHUB_WORKSPACE  = "/github/workspace/ts-loader"
-  }
 }
 
 # test with yarn - commented until they work in docker
@@ -30,9 +27,6 @@ action "test" {
   uses = "./.github/node-chrome"
   runs = "yarn"
   args = "execution-tests"
-  env = {
-    GITHUB_WORKSPACE  = "/github/workspace/ts-loader"
-  }
 }
 
 # filter for a new tag
@@ -40,9 +34,6 @@ action "check for new tag" {
   needs = "test"
   uses = "actions/bin/filter@master"
   args = "tag"
-  env = {
-    GITHUB_WORKSPACE  = "/github/workspace/ts-loader"
-  }
 }
 
 # publish with npm
@@ -51,7 +42,4 @@ action "publish" {
   uses = "actions/npm@1.0.0"
   args = "publish"
   secrets = ["NPM_AUTH_TOKEN"]
-  env = {
-    GITHUB_WORKSPACE  = "/github/workspace/ts-loader"
-  }
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -23,6 +23,7 @@ action "test" {
   needs = "build"
   uses = "docker://zenika/alpine-chrome:with-node"
   args = "test"
+  runs = "yarn"
 }
 
 # filter for a new tag

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -21,9 +21,9 @@ action "build" {
 # test with yarn
 action "test" {
   needs = "build"
-  uses = "docker://zenika/alpine-chrome:with-node"
+  uses = "docker://node:10"
   runs = "yarn"
-  args = "execution-tests"
+  args = "test"
 }
 
 # filter for a new tag

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -22,8 +22,8 @@ action "build" {
 action "test" {
   needs = "build"
   uses = "docker://zenika/alpine-chrome:with-node"
-  args = "test"
   runs = "yarn"
+  args = "execution-tests"
 }
 
 # filter for a new tag

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -8,6 +8,9 @@ action "install" {
   uses = "actions/npm@1.0.0"
   runs = "yarn"
   args = "install"
+  env = {
+    GITHUB_WORKSPACE  = "/github/workspace/ts-loader"
+  }
 }
 
 # build with yarn
@@ -16,6 +19,9 @@ action "build" {
   uses = "actions/npm@1.0.0"
   runs = "yarn"
   args = "build"
+  env = {
+    GITHUB_WORKSPACE  = "/github/workspace/ts-loader"
+  }
 }
 
 # test with yarn - commented until they work in docker
@@ -24,6 +30,9 @@ action "test" {
   uses = "./.github/node-chrome"
   runs = "yarn"
   args = "execution-tests"
+  env = {
+    GITHUB_WORKSPACE  = "/github/workspace/ts-loader"
+  }
 }
 
 # filter for a new tag
@@ -31,6 +40,9 @@ action "check for new tag" {
   needs = "test"
   uses = "actions/bin/filter@master"
   args = "tag"
+  env = {
+    GITHUB_WORKSPACE  = "/github/workspace/ts-loader"
+  }
 }
 
 # publish with npm
@@ -39,4 +51,7 @@ action "publish" {
   uses = "actions/npm@1.0.0"
   args = "publish"
   secrets = ["NPM_AUTH_TOKEN"]
+  env = {
+    GITHUB_WORKSPACE  = "/github/workspace/ts-loader"
+  }
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -21,8 +21,7 @@ action "build" {
 # test with yarn
 action "test" {
   needs = "build"
-  uses = "actions/npm@1.0.0"
-  runs = "yarn"
+  uses = "docker://zenika/alpine-chrome:with-node"
   args = "test"
 }
 

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -23,7 +23,7 @@ action "test" {
   needs = "build"
   uses = "./.github/node-chrome"
   runs = "yarn"
-  args = "test"
+  args = "execution-tests"
 }
 
 # filter for a new tag

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,10 +1,17 @@
 workflow "build, test and publish on release" {
-  on = "release"
+  on = "push"
   resolves = "publish"
+}
+
+# filter for a new tag
+action "check for new tag" {
+  uses = "actions/bin/filter@1.0.0"
+  args = "tag"
 }
 
 # install with yarn
 action "install" {
+  needs = "check for new tag"
   uses = "actions/npm@1.0.0"
   runs = "yarn"
   args = "install"

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -21,8 +21,7 @@ action "build" {
 # test with yarn - commented until they work in docker
 action "test" {
   needs = "build"
-  uses = "docker://zenika/alpine-chrome:with-node"
-#  uses = "./.github/node-chrome"
+  uses = "./.github/node-chrome"
   runs = "yarn"
   args = "execution-tests"
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -5,7 +5,7 @@ workflow "build, test and publish on release" {
 
 # filter for a new tag
 action "check for new tag" {
-  uses = "actions/bin/filter@1.0.0"
+  uses = "actions/bin/filter@master"
   args = "tag"
 }
 

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -18,17 +18,17 @@ action "build" {
   args = "build"
 }
 
-# test with yarn
-action "test" {
-  needs = "build"
-  uses = "docker://node:10"
-  runs = "yarn"
-  args = "test"
-}
+# test with yarn - commented until they work in docker
+#action "test" {
+#  needs = "build"
+#  uses = "docker://node:10"
+#  runs = "yarn"
+#  args = "test"
+#}
 
 # filter for a new tag
 action "check for new tag" {
-  needs = "test"
+  needs = "build"
   uses = "actions/bin/filter@master"
   args = "tag"
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -18,12 +18,12 @@ action "build" {
   args = "build"
 }
 
-# test with yarn - commented until they work in docker
+# test with yarn
 action "test" {
   needs = "build"
   uses = "./.github/node-chrome"
   runs = "yarn"
-  args = "execution-tests"
+  args = "test"
 }
 
 # filter for a new tag

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -19,16 +19,16 @@ action "build" {
 }
 
 # test with yarn - commented until they work in docker
-#action "test" {
-#  needs = "build"
-#  uses = "docker://node:10"
-#  runs = "yarn"
-#  args = "test"
-#}
+action "test" {
+  needs = "build"
+  uses = "docker://zenika/alpine-chrome:with-node"
+  runs = "yarn"
+  args = "execution-tests"
+}
 
 # filter for a new tag
 action "check for new tag" {
-  needs = "build"
+  needs = "test"
   uses = "actions/bin/filter@master"
   args = "tag"
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -21,7 +21,7 @@ action "build" {
 # test with yarn - commented until they work in docker
 action "test" {
   needs = "build"
-  uses = "docker://zenika/alpine-chrome:with-node"
+  uses = "./.github/node-chrome"
   runs = "yarn"
   args = "execution-tests"
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -8,9 +8,6 @@ action "install" {
   uses = "actions/npm@1.0.0"
   runs = "yarn"
   args = "install"
-  env = {
-    GITHUB_WORKSPACE = "/github/workspace/ts-loader"
-  }
 }
 
 # build with yarn

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -33,10 +33,10 @@ action "check for new tag" {
   args = "tag"
 }
 
-# publish with npm
-action "publish" {
-  needs = "check for new tag"
-  uses = "actions/npm@1.0.0"
-  args = "publish"
-  secrets = ["NPM_AUTH_TOKEN"]
-}
+# publish with npm - commented until this issue is resolved: https://github.com/actions/bin/issues/13
+#action "publish" {
+#  needs = "check for new tag"
+#  uses = "actions/npm@1.0.0"
+#  args = "publish"
+#  secrets = ["NPM_AUTH_TOKEN"]
+#}

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -21,7 +21,8 @@ action "build" {
 # test with yarn - commented until they work in docker
 action "test" {
   needs = "build"
-  uses = "./.github/node-chrome"
+  uses = "docker://zenika/alpine-chrome:with-node"
+#  uses = "./.github/node-chrome"
   runs = "yarn"
   args = "execution-tests"
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -3,15 +3,8 @@ workflow "build, test and publish on release" {
   resolves = "publish"
 }
 
-# filter for a new tag
-action "check for new tag" {
-  uses = "actions/bin/filter@master"
-  args = "tag"
-}
-
 # install with yarn
 action "install" {
-  needs = "check for new tag"
   uses = "actions/npm@1.0.0"
   runs = "yarn"
   args = "install"
@@ -33,9 +26,16 @@ action "test" {
   args = "test"
 }
 
+# filter for a new tag
+action "check for new tag" {
+  needs = "test"
+  uses = "actions/bin/filter@master"
+  args = "tag"
+}
+
 # publish with npm
 action "publish" {
-  needs = "test"
+  needs = "check for new tag"
   uses = "actions/npm@1.0.0"
   args = "publish"
   secrets = ["NPM_AUTH_TOKEN"]

--- a/.github/node-chrome/Dockerfile
+++ b/.github/node-chrome/Dockerfile
@@ -1,0 +1,21 @@
+# Taken from https://raw.githubusercontent.com/filipesilva/ng-github-actions/master/.github/node-chrome/Dockerfile
+
+# Taken from https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
+# Using the "jessie" image because without it there's a "Error: spawn ps ENOENT" after karma/protractor exits.
+FROM node:10-jessie-slim
+
+# See https://crbug.com/795759
+RUN apt-get update && apt-get install -yq libgconf-2-4
+
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
+# installs, work.
+RUN apt-get update && apt-get install -y wget --no-install-recommends \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get purge --auto-remove -y curl \
+    && rm -rf /src/*.deb

--- a/.github/node-chrome/Dockerfile
+++ b/.github/node-chrome/Dockerfile
@@ -1,8 +1,6 @@
 # Taken from https://raw.githubusercontent.com/filipesilva/ng-github-actions/master/.github/node-chrome/Dockerfile
-
-# Taken from https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
-# Using the "jessie" image because without it there's a "Error: spawn ps ENOENT" after karma/protractor exits.
-FROM node:10-jessie-slim
+# and https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
+FROM node:10-slim
 
 # See https://crbug.com/795759
 RUN apt-get update && apt-get install -yq libgconf-2-4

--- a/.github/node-chrome/Dockerfile
+++ b/.github/node-chrome/Dockerfile
@@ -1,6 +1,6 @@
 # Taken from https://raw.githubusercontent.com/filipesilva/ng-github-actions/master/.github/node-chrome/Dockerfile
 # and https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
-FROM node:10-slim
+FROM node:10
 
 # See https://crbug.com/795759
 RUN apt-get update && apt-get install -yq libgconf-2-4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ addons:
   chrome: stable
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
 sudo: required

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,18 +16,18 @@ RUN apt-get update && apt-get install -y wget --no-install-recommends \
     && apt-get purge --auto-remove -y curl \
     && rm -rf /src/*.deb
 
-WORKDIR /ts-loader
+WORKDIR /TypeStrong/ts-loader
 
 # install packages
-COPY package.json yarn.lock index.js /ts-loader/
+COPY package.json yarn.lock index.js /TypeStrong/ts-loader/
 RUN yarn
 
 # build
-COPY src /ts-loader/src
+COPY src /TypeStrong/ts-loader/src
 RUN yarn build
 
 # test
-COPY test /ts-loader/test
+COPY test /TypeStrong/ts-loader/test
 
 # build and run tests with:
 # docker build -t ts-loader . 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:10-slim
+
+# See https://crbug.com/795759
+RUN apt-get update && apt-get install -yq libgconf-2-4
+
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
+# installs, work.
+RUN apt-get update && apt-get install -y wget --no-install-recommends \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get purge --auto-remove -y curl \
+    && rm -rf /src/*.deb
+
+# install packages
+ADD package.json yarn.lock index.js /
+RUN yarn
+
+# build
+COPY src src
+RUN yarn build
+
+# test
+COPY test test
+RUN yarn execution-tests
+
+# build and run execution tests with:
+# docker build -t ts-loader .
+
+
+
+# docker build -t ts-loader . && docker run -rm ts-loader
+# docker build -t ts-loader . && docker run -it ts-loader

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:10
 
 # See https://crbug.com/795759
 RUN apt-get update && apt-get install -yq libgconf-2-4
@@ -16,22 +16,19 @@ RUN apt-get update && apt-get install -y wget --no-install-recommends \
     && apt-get purge --auto-remove -y curl \
     && rm -rf /src/*.deb
 
+WORKDIR /ts-loader
+
 # install packages
-ADD package.json yarn.lock index.js /
+COPY package.json yarn.lock index.js /ts-loader/
 RUN yarn
 
 # build
-COPY src src
+COPY src /ts-loader/src
 RUN yarn build
 
 # test
-COPY test test
-RUN yarn execution-tests
+COPY test /ts-loader/test
 
-# build and run execution tests with:
-# docker build -t ts-loader .
-
-
-
-# docker build -t ts-loader . && docker run -rm ts-loader
-# docker build -t ts-loader . && docker run -it ts-loader
+# build and run tests with:
+# docker build -t ts-loader . 
+# docker run -it ts-loader yarn test

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "tslint --project \"./src\"",
     "comparison-tests": "tsc --project \"./test/comparison-tests\" && npm link ./test/comparison-tests/testLib && node test/comparison-tests/run-tests.js",
     "comparison-tests-generate": "node test/comparison-tests/stub-new-version.js",
-    "execution-tests": "npm i -g pnpm && node test/execution-tests/run-tests.js",
+    "execution-tests": "node test/execution-tests/run-tests.js",
     "test": "node test/run-tests.js"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "comparison-tests": "tsc --project \"./test/comparison-tests\" && npm link ./test/comparison-tests/testLib && node test/comparison-tests/run-tests.js",
     "comparison-tests-generate": "node test/comparison-tests/stub-new-version.js",
     "execution-tests": "node test/execution-tests/run-tests.js",
-    "test": "node test/run-tests.js"
+    "test": "node test/run-tests.js",
+    "docker:build": "docker build -t ts-loader .",
+    "postdocker:build": "docker run -it ts-loader yarn test"
   },
   "husky": {
     "hooks": {

--- a/test/comparison-tests/create-and-execute-test.js
+++ b/test/comparison-tests/create-and-execute-test.js
@@ -416,7 +416,7 @@ function getNormalisedFileContent(file, location) {
                 return 'at ' + remainingPathAndColon + 'irrelevant-line-number' + colon + 'irrelevant-column-number';
             })
             // strip C:/projects/ts-loader/.test/
-            .replace(/(C\:\/)?[\w|\/]*\/ts-loader\/\.test/g, '')
+            .replace(/(C\:\/)?[\w|\/]*\/(ts-loader|workspace)\/\.test/g, '')
             .replace(/webpack:\/\/(C:\/)?[\w|\/|-]*\/comparison-tests\//g, 'webpack://comparison-tests/')
             .replace(/WEBPACK FOOTER\/n\/ (C:\/)?[\w|\/|-]*\/comparison-tests\//g, 'WEBPACK FOOTER/n/ /ts-loader/test/comparison-tests/')
             .replace(/!\** (C\:\/)?[\w|\/|-]*\/comparison-tests\//g, '!*** /ts-loader/test/comparison-tests/')
@@ -440,9 +440,9 @@ function normaliseString(platformSpecificContent) {
         .replace(new RegExp(regexEscape('\\'), 'g'), '/')
         .replace(new RegExp(regexEscape('//'), 'g'), '/')
         // replace C:/source/ts-loader/index.js or /home/travis/build/TypeStrong/ts-loader/index.js with ts-loader
-        .replace(/ \S+[\/|\\]ts-loader[\/|\\]index.js/g, 'ts-loader')
+        .replace(/ \S+[\/|\\](ts-loader|workspace)[\/|\\]index.js/g, 'ts-loader')
         // replace (C:/source/ts-loader/dist/index.js with (ts-loader)
-        .replace(/\(\S+[\/|\\]ts-loader[\/|\\]dist[\/|\\]index.js:\d*:\d*\)/g, '(ts-loader)');
+        .replace(/\(\S+[\/|\\](ts-loader|workspace)[\/|\\]dist[\/|\\]index.js:\d*:\d*\)/g, '(ts-loader)');
 }
 
 /**

--- a/test/execution-tests/1.8.2_allowJs-entryFileIsJs/karma.conf.js
+++ b/test/execution-tests/1.8.2_allowJs-entryFileIsJs/karma.conf.js
@@ -7,8 +7,14 @@ var reporterOptions = require('../../reporterOptions');
 
 module.exports = function(config) {
   config.set({
-    browsers: [ 'ChromeHeadless' ],
-
+    browsers: ['ChromeHeadlessNoSandbox'],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      }
+    },
+    
     files: [
       // This loads all the tests
       './**/*.tests.js'

--- a/test/execution-tests/1.8.2_allowJs-entryFileIsJs/karma.conf.js
+++ b/test/execution-tests/1.8.2_allowJs-entryFileIsJs/karma.conf.js
@@ -9,10 +9,14 @@ module.exports = function(config) {
   config.set({
     browsers: ['ChromeHeadlessNoSandbox'],
     customLaunchers: {
-      ChromeHeadlessNoSandbox: {
-        base: 'ChromeHeadless',
-        flags: ['--no-sandbox']
-      }
+        ChromeHeadlessNoSandbox: {
+            base: 'ChromeHeadless',
+            flags: [
+                '--no-sandbox', // required to run without privileges in docker
+                '--user-data-dir=/tmp/chrome-test-profile',
+                '--disable-web-security'
+            ]
+        }
     },
     
     files: [

--- a/test/execution-tests/1.8.2_allowJs-entryFileIsJs/karma.conf.js
+++ b/test/execution-tests/1.8.2_allowJs-entryFileIsJs/karma.conf.js
@@ -1,57 +1,14 @@
 /* eslint-disable no-var, strict */
 'use strict';
-var path = require('path');
-var webpack = require('webpack');
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: ['ChromeHeadlessNoSandbox'],
-    customLaunchers: {
-        ChromeHeadlessNoSandbox: {
-            base: 'ChromeHeadless',
-            flags: [
-                '--no-sandbox', // required to run without privileges in docker
-                '--user-data-dir=/tmp/chrome-test-profile',
-                '--disable-web-security'
-            ]
-        }
-    },
-    
-    files: [
-      // This loads all the tests
-      './**/*.tests.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      './**/*.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions,
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: ['./**/*.tests.js']
+    })
+  );
 };

--- a/test/execution-tests/1.8.2_babel-allowSyntheticDefaultImports/karma.conf.js
+++ b/test/execution-tests/1.8.2_babel-allowSyntheticDefaultImports/karma.conf.js
@@ -1,47 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
-var path = require('path');
-var webpack = require('webpack');
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This ensures we have the es6 shims in place from babel and then loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions,
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/2.0.3_typesResolution/karma.conf.js
+++ b/test/execution-tests/2.0.3_typesResolution/karma.conf.js
@@ -1,47 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
-var path = require('path');
-var webpack = require('webpack');
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions    
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/2.1.4_babel-allowJsImportTypes/karma.conf.js
+++ b/test/execution-tests/2.1.4_babel-allowJsImportTypes/karma.conf.js
@@ -1,46 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  // Documentation: https://karma-runner.github.io/0.13/config/configuration-file.html
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This ensures we have the es6 shims in place and then loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/2.1.4_babel-es2016/karma.conf.js
+++ b/test/execution-tests/2.1.4_babel-es2016/karma.conf.js
@@ -1,45 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This ensures we have the es6 shims in place from babel and then loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions,
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/2.1.4_babel-react/karma.conf.js
+++ b/test/execution-tests/2.1.4_babel-react/karma.conf.js
@@ -1,46 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  // Documentation: https://karma-runner.github.io/0.13/config/configuration-file.html
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This ensures we have the es6 shims in place and then loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/2.1.4_react/karma.conf.js
+++ b/test/execution-tests/2.1.4_react/karma.conf.js
@@ -1,46 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  // Documentation: https://karma-runner.github.io/0.13/config/configuration-file.html
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This ensures we have the es6 shims in place and then loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/2.4.1_babel-importCodeSplitting/karma.conf.js
+++ b/test/execution-tests/2.4.1_babel-importCodeSplitting/karma.conf.js
@@ -1,46 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  // Documentation: https://karma-runner.github.io/0.13/config/configuration-file.html
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This ensures we have the es6 shims in place and then loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/2.4.1_importCodeSplitting/karma.conf.js
+++ b/test/execution-tests/2.4.1_importCodeSplitting/karma.conf.js
@@ -1,46 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  // Documentation: https://karma-runner.github.io/0.13/config/configuration-file.html
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This ensures we have the es6 shims in place and then loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/2.4.1_nodeResolutionAllowJs/karma.conf.js
+++ b/test/execution-tests/2.4.1_nodeResolutionAllowJs/karma.conf.js
@@ -1,47 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
-var path = require('path');
-var webpack = require('webpack');
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/3.0.1_projectReferences/karma.conf.js
+++ b/test/execution-tests/3.0.1_projectReferences/karma.conf.js
@@ -1,45 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/3.0.1_resolveJsonModule/karma.conf.js
+++ b/test/execution-tests/3.0.1_resolveJsonModule/karma.conf.js
@@ -1,47 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
-var path = require('path');
-var webpack = require('webpack');
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/3.0.1_resolveModuleName/karma.conf.js
+++ b/test/execution-tests/3.0.1_resolveModuleName/karma.conf.js
@@ -1,47 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
-var path = require('path');
-var webpack = require('webpack');
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/allowTsInNodeModules/karma.conf.js
+++ b/test/execution-tests/allowTsInNodeModules/karma.conf.js
@@ -1,47 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
-var path = require('path');
-var webpack = require('webpack');
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/babel-codeSplitting/karma.conf.js
+++ b/test/execution-tests/babel-codeSplitting/karma.conf.js
@@ -1,47 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
-var path = require('path');
-var webpack = require('webpack');
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/babel-es2015/karma.conf.js
+++ b/test/execution-tests/babel-es2015/karma.conf.js
@@ -1,47 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
-var path = require('path');
-var webpack = require('webpack');
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This ensures we have the es6 shims in place from babel and then loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/babel-es6resolveParent/karma.conf.js
+++ b/test/execution-tests/babel-es6resolveParent/karma.conf.js
@@ -1,47 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
-var path = require('path');
-var webpack = require('webpack');
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This ensures we have the es6 shims in place from babel and then loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/basic-happypack/karma.conf.js
+++ b/test/execution-tests/basic-happypack/karma.conf.js
@@ -1,48 +1,32 @@
 /* eslint-disable no-var, strict */
 'use strict';
-var path = require('path');
-var webpack = require('webpack');
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
+  config.set(
+    Object.assign(
+      {},
+      makeKarmaConfig({
+        config,
+        webpackConfig,
+        files: [
+          // This ensures we have the es6 shims in place from babel and then loads all the tests
+          'main.js'
+        ]
+      }),
+      {
+        webpack: {
+          devtool: 'inline-source-map',
+          mode: webpackConfig.mode,
+          module: webpackConfig.module,
+          resolve: webpackConfig.resolve,
+          plugins: webpackConfig.plugins,
 
-    files: [
-      // This loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-      plugins: webpackConfig.plugins,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
+          // for test harness purposes only, you would not need this in a normal project
+          resolveLoader: webpackConfig.resolveLoader
+        }
       }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+    )
+  );
 };

--- a/test/execution-tests/basic/karma.conf.js
+++ b/test/execution-tests/basic/karma.conf.js
@@ -1,47 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
-var path = require('path');
-var webpack = require('webpack');
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/nodeResolution/karma.conf.js
+++ b/test/execution-tests/nodeResolution/karma.conf.js
@@ -1,47 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
-var path = require('path');
-var webpack = require('webpack');
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/option-context/karma.conf.js
+++ b/test/execution-tests/option-context/karma.conf.js
@@ -1,46 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  // Documentation: https://karma-runner.github.io/0.13/config/configuration-file.html
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This ensures we have the es6 shims in place and then loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/execution-tests/run-tests.js
+++ b/test/execution-tests/run-tests.js
@@ -106,7 +106,7 @@ function runTests(testName) {
 
     if (pathExists(path.join(testPath, 'shrinkwrap.yaml'))) {
         console.log('npx pnpm install into ' + testPath);
-        execSync('npx pnpm install', { cwd: testPath, stdio: 'inherit' });
+        execSync('npx pnpm install --force', { cwd: testPath, stdio: 'inherit' });
     } else if (pathExists(path.join(testPath, 'package.json'))) {
         console.log('yarn install into ' + testPath);
         execSync('yarn install', { cwd: testPath, stdio: 'inherit' });

--- a/test/execution-tests/run-tests.js
+++ b/test/execution-tests/run-tests.js
@@ -105,8 +105,8 @@ function runTests(testName) {
     var karmaConfPath = path.join(testPath, 'karma.conf.js');
 
     if (pathExists(path.join(testPath, 'shrinkwrap.yaml'))) {
-        console.log('pnpm install into ' + testPath);
-        execSync('pnpm install', { cwd: testPath, stdio: 'inherit' });
+        console.log('npx pnpm install into ' + testPath);
+        execSync('npx pnpm install', { cwd: testPath, stdio: 'inherit' });
     } else if (pathExists(path.join(testPath, 'package.json'))) {
         console.log('yarn install into ' + testPath);
         execSync('yarn install', { cwd: testPath, stdio: 'inherit' });

--- a/test/execution-tests/run-tests.js
+++ b/test/execution-tests/run-tests.js
@@ -115,7 +115,7 @@ function runTests(testName) {
     try {
         if (pathExists(path.join(testPath, 'karma.conf.js'))) {
             var singleRunOrWatch = watch ? '' : ' --single-run';
-            execSync('karma start --reporters mocha' + singleRunOrWatch + ' --browsers ChromeHeadless', { cwd: testPath, stdio: 'inherit' });
+            execSync('karma start --reporters mocha' + singleRunOrWatch + ' --browsers ChromeHeadlessNoSandbox', { cwd: testPath, stdio: 'inherit' });
 
             passingTests.push(testName);
         } else {

--- a/test/execution-tests/simpleDependency/karma.conf.js
+++ b/test/execution-tests/simpleDependency/karma.conf.js
@@ -1,47 +1,17 @@
 /* eslint-disable no-var, strict */
 'use strict';
-var path = require('path');
-var webpack = require('webpack');
 var webpackConfig = require('./webpack.config.js');
-var reporterOptions = require('../../reporterOptions');
+var makeKarmaConfig = require('../../karmaConfig');
 
 module.exports = function(config) {
-  config.set({
-    browsers: [ 'ChromeHeadless' ],
-
-    files: [
-      // This loads all the tests
-      'main.js'
-    ],
-
-    port: 9876,
-
-    frameworks: [ 'jasmine' ],
-
-    logLevel: config.LOG_INFO, //config.LOG_DEBUG
-
-    preprocessors: {
-      'main.js': [ 'webpack', 'sourcemap' ]
-    },
-
-    webpack: {
-      devtool: 'inline-source-map',
-      mode: webpackConfig.mode,
-      module: webpackConfig.module,
-      resolve: webpackConfig.resolve,
-
-      // for test harness purposes only, you would not need this in a normal project
-      resolveLoader: webpackConfig.resolveLoader
-    },
-
-    webpackMiddleware: {
-      quiet: true,
-      stats: {
-        colors: true
-      }
-    },
-
-    // reporter options
-    mochaReporter: reporterOptions
-  });
+  config.set(
+    makeKarmaConfig({
+      config,
+      webpackConfig,
+      files: [
+        // This ensures we have the es6 shims in place from babel and then loads all the tests
+        'main.js'
+      ]
+    })
+  );
 };

--- a/test/karmaConfig.js
+++ b/test/karmaConfig.js
@@ -1,0 +1,51 @@
+module.exports = function makeKarmaConfig({ config, webpackConfig, files }) {
+  return {
+    browsers: ['ChromeHeadlessNoSandbox'],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      }
+    },
+
+    // This loads all the tests
+    files,
+
+    port: 9876,
+
+    frameworks: ['jasmine'],
+
+    logLevel: config.LOG_INFO, //config.LOG_DEBUG
+
+    preprocessors: {
+      './**/*.js': ['webpack', 'sourcemap']
+    },
+
+    webpack: {
+      devtool: 'inline-source-map',
+      mode: webpackConfig.mode,
+      module: webpackConfig.module,
+      resolve: webpackConfig.resolve,
+
+      // for test harness purposes only, you would not need this in a normal project
+      resolveLoader: webpackConfig.resolveLoader
+    },
+
+    webpackMiddleware: {
+      quiet: true,
+      stats: {
+        colors: true
+      }
+    },
+
+    // reporter options
+    mochaReporter: {
+      colors: {
+        success: 'green',
+        info: 'cyan',
+        warning: 'bgBlue',
+        error: 'bgRed'
+      }
+    }
+  };
+};

--- a/test/reporterOptions.js
+++ b/test/reporterOptions.js
@@ -1,8 +1,0 @@
-module.exports = {
-    colors: {
-        success: 'green',
-        info: 'cyan',
-        warning: 'bgBlue',
-        error: 'bgRed'
-    }
-};


### PR DESCRIPTION
- publish event not available-switch to filter on push
- need to get comparison tests passing in a docker container; got execution tests passing which is enough peace of mind to greenlight a release.

It looks like filtering makes subsequent actions in GitHub show as cancelled because the filter item has failed. That seems... Not quite right? Eg:

 "Action `publish' cancelled because action `check for new tag' failed". Believe related to: https://github.com/actions/bin/issues/13
 
I'm just going to hack on this branch until I've got something I'm happy with.  Then I will definitely squash and merge rather than just merge 😄 