### PR TITLE
internal: remove usage of hand crafted webpack typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.4.5
+
+* [use @types/webpack for loader typings](https://github.com/TypeStrong/ts-loader/pull/927) - thanks @LukeSheard!
+
 ## v5.4.4
 
 * [refactor: add common appendTsTsxSuffixesIfRequired function to instance](https://github.com/TypeStrong/ts-loader/pull/924) - thanks @johnnyreilly!

--- a/examples/react-babel-karma-gulp/yarn.lock
+++ b/examples/react-babel-karma-gulp/yarn.lock
@@ -22,8 +22,9 @@
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.6.0.tgz#997b41a27752b4850af2683bc4a8d8222c25bd02"
 
 "@types/node@*":
-  version "8.0.45"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.45.tgz#89fad82439d5624e1b5c6b42f0f5d85136dcdecc"
+  version "11.13.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.8.tgz#e5d71173c95533be9842b2c798978f095f912aab"
+  integrity sha512-szA3x/3miL90ZJxUCzx9haNbK5/zmPieGraZEe4WI+3srN0eGLiT22NXeMHmyhNEopn+IrxqMc7wdVwvPl8meg==
 
 "@types/react-bootstrap@0.31.6":
   version "0.31.6"

--- a/examples/thread-loader/yarn.lock
+++ b/examples/thread-loader/yarn.lock
@@ -3,8 +3,9 @@
 
 
 "@types/node@*":
-  version "9.4.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.6.tgz#d8176d864ee48753d053783e4e463aec86b8d82e"
+  version "11.13.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.8.tgz#e5d71173c95533be9842b2c798978f095f912aab"
+  integrity sha512-szA3x/3miL90ZJxUCzx9haNbK5/zmPieGraZEe4WI+3srN0eGLiT22NXeMHmyhNEopn+IrxqMc7wdVwvPl8meg==
 
 abbrev@1:
   version "1.1.1"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/micromatch": "^3.1.0",
     "@types/node": "*",
     "@types/semver": "^5.4.0",
-    "@types/webpack": "^4.4.27",
+    "@types/webpack": "^4.4.29",
     "babel": "^6.0.0",
     "babel-core": "^6.0.0",
     "babel-loader": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@types/micromatch": "^3.1.0",
-    "@types/node": "^10.0.0",
+    "@types/node": "*",
     "@types/semver": "^5.4.0",
     "@types/webpack": "^4.4.27",
     "babel": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/micromatch": "^3.1.0",
     "@types/node": "^10.0.0",
     "@types/semver": "^5.4.0",
+    "@types/webpack": "^4.4.27",
     "babel": "^6.0.0",
     "babel-core": "^6.0.0",
     "babel-loader": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist/types/index.d.ts",

--- a/src/compilerSetup.ts
+++ b/src/compilerSetup.ts
@@ -1,7 +1,6 @@
 import * as semver from 'semver';
 import * as typescript from 'typescript';
 
-import * as constants from './constants';
 import { LoaderOptions } from './interfaces';
 import * as logger from './logger';
 
@@ -66,9 +65,9 @@ export function getCompilerOptions(
   if (
     compilerOptions.module === undefined &&
     (compilerOptions.target !== undefined &&
-      compilerOptions.target < constants.ScriptTargetES2015)
+      compilerOptions.target < typescript.ScriptTarget.ES2015)
   ) {
-    compilerOptions.module = constants.ModuleKindCommonJs;
+    compilerOptions.module = typescript.ModuleKind.CommonJS;
   }
 
   return compilerOptions;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,9 @@
 import { Chalk } from 'chalk';
 import * as path from 'path';
 import * as typescript from 'typescript';
-import { LoaderOptions, Webpack, WebpackError } from './interfaces';
+import * as webpack from 'webpack';
+
+import { LoaderOptions, WebpackError } from './interfaces';
 import * as logger from './logger';
 import { formatErrors } from './utils';
 
@@ -13,7 +15,7 @@ interface ConfigFile {
 export function getConfigFile(
   compiler: typeof typescript,
   colors: Chalk,
-  loader: Webpack,
+  loader: webpack.loader.LoaderContext,
   loaderOptions: LoaderOptions,
   compilerCompatible: boolean,
   log: logger.Logger,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,10 +7,6 @@ export const LineFeed = '\n';
 export const CarriageReturnLineFeedCode = 0;
 export const LineFeedCode = 1;
 
-export const ScriptTargetES2015 = 2;
-
-export const ModuleKindCommonJs = 1;
-
 export const extensionRegex = /\.[^.]+$/;
 export const tsxRegex = /\.tsx$/i;
 export const tsTsxRegex = /\.ts(x?)$/i;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,16 @@
 import * as loaderUtils from 'loader-utils';
 import * as path from 'path';
 import * as typescript from 'typescript';
+import * as webpack from 'webpack';
 
 import * as constants from './constants';
 import { getEmitOutput, getTypeScriptInstance } from './instances';
 import {
-  AsyncCallback,
-  Compiler,
   LoaderOptions,
   LoaderOptionsCache,
   LogLevel,
   TSFile,
-  TSInstance,
-  Webpack
+  TSInstance
 } from './interfaces';
 import {
   appendSuffixesIfMatch,
@@ -23,16 +21,16 @@ import {
   validateSourceMapOncePerProject
 } from './utils';
 
-const webpackInstances: Compiler[] = [];
+const webpackInstances: webpack.Compiler[] = [];
 const loaderOptionsCache: LoaderOptionsCache = {};
 
 /**
  * The entry point for ts-loader
  */
-function loader(this: Webpack, contents: string) {
+function loader(this: webpack.loader.LoaderContext, contents: string) {
   // tslint:disable-next-line:no-unused-expression strict-boolean-expressions
   this.cacheable && this.cacheable();
-  const callback = this.async();
+  const callback = this.async() as webpack.loader.loaderCallback;
   const options = getLoaderOptions(this);
   const instanceOrError = getTypeScriptInstance(options, this);
 
@@ -51,9 +49,9 @@ function loader(this: Webpack, contents: string) {
 }
 
 function successLoader(
-  loaderContext: Webpack,
+  loaderContext: webpack.loader.LoaderContext,
   contents: string,
-  callback: AsyncCallback,
+  callback: webpack.loader.loaderCallback,
   options: LoaderOptions,
   instance: TSInstance
 ) {
@@ -157,10 +155,10 @@ function makeSourceMapAndFinish(
   outputText: string | undefined,
   filePath: string,
   contents: string,
-  loaderContext: Webpack,
+  loaderContext: webpack.loader.LoaderContext,
   options: LoaderOptions,
   fileVersion: number,
-  callback: AsyncCallback
+  callback: webpack.loader.loaderCallback
 ) {
   if (outputText === null || outputText === undefined) {
     const additionalGuidance =
@@ -198,7 +196,7 @@ function makeSourceMapAndFinish(
  * either retrieves loader options from the cache
  * or creates them, adds them to the cache and returns
  */
-function getLoaderOptions(loaderContext: Webpack) {
+function getLoaderOptions(loaderContext: webpack.loader.LoaderContext) {
   // differentiate the TypeScript instance based on the webpack instance
   let webpackIndex = webpackInstances.indexOf(loaderContext._compiler);
   if (webpackIndex === -1) {
@@ -390,7 +388,7 @@ function getEmit(
   rawFilePath: string,
   filePath: string,
   instance: TSInstance,
-  loaderContext: Webpack
+  loaderContext: webpack.loader.LoaderContext
 ) {
   const outputFiles = getEmitOutput(instance, filePath);
 
@@ -460,7 +458,7 @@ function getTranspilationEmit(
   fileName: string,
   contents: string,
   instance: TSInstance,
-  loaderContext: Webpack
+  loaderContext: webpack.loader.LoaderContext
 ) {
   const {
     outputText,
@@ -495,7 +493,7 @@ function makeSourceMap(
   outputText: string,
   filePath: string,
   contents: string,
-  loaderContext: Webpack
+  loaderContext: webpack.loader.LoaderContext
 ) {
   if (sourceMapText === undefined) {
     return { output: outputText, sourceMap: undefined };

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -29,9 +29,6 @@ import { makeWatchRun } from './watch-run';
 
 const instances = {} as TSInstances;
 
-// TODO: workaround for issues with webpack typings
-type PatchedHookCallback = any;
-
 /**
  * The loader is executed once for each file seen by webpack. However, we need to keep
  * a persistent instance of TypeScript that contains all of the files in the program
@@ -310,10 +307,10 @@ function successfulTypeScriptInstance(
     );
   }
 
-  loader._compiler.hooks.afterCompile.tapAsync('ts-loader', makeAfterCompile(
-    instance,
-    configFilePath
-  ) as PatchedHookCallback);
+  loader._compiler.hooks.afterCompile.tapAsync(
+    'ts-loader',
+    makeAfterCompile(instance, configFilePath)
+  );
   loader._compiler.hooks.watchRun.tapAsync('ts-loader', makeWatchRun(instance));
 
   return { instance };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,12 +1,7 @@
-import * as typescript from 'typescript';
 export { ModuleResolutionHost } from 'typescript';
-import { Chalk } from 'chalk';
+import * as typescript from 'typescript';
 
-export interface SourceMap {
-  sources: any[];
-  file: string;
-  sourcesContent: string[];
-}
+import { Chalk } from 'chalk';
 
 export interface ErrorInfo {
   code: number;
@@ -18,113 +13,6 @@ export interface ErrorInfo {
   context: string;
 }
 
-export type AsyncCallback = (
-  err: Error | WebpackError | null,
-  source?: string,
-  map?: string
-) => void;
-
-/**
- * Details here: https://webpack.github.io/docs/loaders.html#loader-context
- */
-export interface Webpack {
-  _compiler: Compiler;
-  _module: WebpackModule;
-  /**
-   * Make this loader result cacheable. By default it’s not cacheable.
-   *
-   * A cacheable loader must have a deterministic result, when inputs and dependencies haven’t changed. This means the loader shouldn’t have other dependencies than specified with this.addDependency. Most loaders are deterministic and cacheable.
-   */
-  cacheable: () => void;
-  /**
-   * The directory of the module. Can be used as context for resolving other stuff.
-   */
-  context: string;
-  /**
-   * The root directory of the Webpack project.
-   * Starting with webpack 4, the formerly `this.options.context` is provided as `this.rootContext`.
-   */
-  rootContext: string;
-  /**
-   * The resolved request string.
-   * eg: "/abc/loader1.js?xyz!/abc/node_modules/loader2/index.js!/abc/resource.js?rrr"
-   */
-  request: string;
-  /**
-   * The query of the request for the current loader.
-   */
-  query: string;
-  /**
-   * A data object shared between the pitch and the normal phase.
-   */
-  data: Object;
-  async: () => AsyncCallback;
-  /**
-   * The resource part of the request, including query.
-   * eg: "/abc/resource.js?rrr"
-   */
-  resource: string;
-  /**
-   * The resource file.
-   * eg: "/abc/resource.js"
-   */
-  resourcePath: string;
-  /**
-   * The query of the resource.
-   * eg: "?rrr"
-   */
-  resourceQuery: string;
-  /**
-   * Resolve a request like a require expression.
-   */
-  resolve: (
-    context: string,
-    request: string,
-    callback: (err: Error, result: string) => void
-  ) => void;
-  /**
-   * Resolve a request like a require expression.
-   */
-  resolveSync: (context: string, request: string) => string;
-  /**
-   * Add a file as dependency of the loader result in order to make them watchable.
-   */
-  addDependency: (file: string) => void;
-  /**
-   * Add a directory as dependency of the loader result.
-   */
-  addContextDependency: (directory: string) => void;
-  /**
-   * Remove all dependencies of the loader result. Even initial dependencies and these of other loaders. Consider using pitch.
-   */
-  clearDependencies: () => void;
-  /**
-   * Emit a warning.
-   */
-  emitWarning: (message: Error) => void;
-  /**
-   * Emit an error.
-   */
-  emitError: (message: Error) => void;
-  /**
-   * Emit a file. This is webpack-specific
-   */
-  emitFile: (fileName: string, text: string) => void; // unused
-}
-
-export interface Compiler {
-  plugin: (name: string, callback: Function) => void;
-
-  hooks: any; // TODO: Define this
-
-  /**
-   * The options passed to the Compiler.
-   */
-  options: {
-    resolve: Resolve;
-  };
-}
-
 export type FileLocation = { line: number; character: number };
 
 export interface WebpackError {
@@ -134,34 +22,6 @@ export interface WebpackError {
   location?: FileLocation;
   loaderSource: string;
 }
-
-/**
- * webpack/lib/Compilation.js
- */
-export interface WebpackCompilation {
-  compiler: WebpackCompiler;
-  errors: WebpackError[];
-  modules: WebpackModule[];
-  assets: {
-    [index: string]: {
-      size: () => number;
-      source: () => string;
-    };
-  };
-}
-
-/**
- * webpack/lib/Compiler.js
- */
-export interface WebpackCompiler {
-  isChild(): boolean;
-  context: string; // a guess
-  outputPath: string;
-  watchFileSystem: WebpackNodeWatchFileSystem;
-  /** key is filepath and value is Date as a number */
-  fileTimestamps: Map<string, number>;
-}
-
 export interface WebpackModule {
   resource: string;
   errors: WebpackError[];
@@ -169,54 +29,6 @@ export interface WebpackModule {
     tsLoaderFileVersion: number;
     tsLoaderDefinitionFileVersions: string[];
   };
-}
-
-export interface Watcher {
-  getTimes(): { [filePath: string]: number };
-}
-
-export interface WebpackNodeWatchFileSystem {
-  watcher?: Watcher;
-  wfs?: {
-    watcher: Watcher;
-  };
-}
-
-export interface Resolve {
-  /** Replace modules by other modules or paths. */
-  alias?: { [key: string]: string };
-  /**
-   * The directory (absolute path) that contains your modules.
-   * May also be an array of directories.
-   * This setting should be used to add individual directories to the search path.
-   */
-  root?: string | string[];
-  /**
-   * An array of directory names to be resolved to the current directory as well as its ancestors, and searched for modules.
-   * This functions similarly to how node finds “node_modules” directories.
-   * For example, if the value is ["mydir"], webpack will look in “./mydir”, “../mydir”, “../../mydir”, etc.
-   */
-  modulesDirectories?: string[];
-  /**
-   * A directory (or array of directories absolute paths),
-   * in which webpack should look for modules that weren’t found in resolve.root or resolve.modulesDirectories.
-   */
-  fallback?: string | string[];
-  /**
-   * An array of extensions that should be used to resolve modules.
-   * For example, in order to discover CoffeeScript files, your array should contain the string ".coffee".
-   */
-  extensions?: string[];
-  /** Check these fields in the package.json for suitable files. */
-  packageMains?: Array<string | string[]>;
-  /** Check this field in the package.json for an object. Key-value-pairs are threaded as aliasing according to this spec */
-  packageAlias?: Array<string | string[]>;
-  /**
-   * Enable aggressive but unsafe caching for the resolving of a part of your files.
-   * Changes to cached paths may cause failure (in rare cases). An array of RegExps, only a RegExp or true (all files) is expected.
-   * If the resolved path matches, it’ll be cached.
-   */
-  unsafeCache?: RegExp | RegExp[] | boolean;
 }
 
 export type ResolveSync = (

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -14,7 +14,7 @@ export interface Logger {
   logError: LoggerFunc;
 }
 
-enum LogLevel {
+export enum LogLevel {
   INFO = 1,
   WARN = 2,
   ERROR = 3

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,8 +1,10 @@
-import { Resolve, ResolveSync } from './interfaces';
+import * as webpack from 'webpack';
+
+import { ResolveSync } from './interfaces';
 
 // tslint:disable-next-line:no-submodule-imports
 const node = require('enhanced-resolve/lib/node');
 
-export function makeResolver(options: { resolve: Resolve }): ResolveSync {
+export function makeResolver(options: webpack.Configuration): ResolveSync {
   return node.create.sync(options.resolve);
 }

--- a/src/servicesHost.ts
+++ b/src/servicesHost.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as typescript from 'typescript';
+import * as webpack from 'webpack';
 
 import * as constants from './constants';
 import {
@@ -9,8 +10,7 @@ import {
   ResolvedModule,
   ResolveSync,
   TSInstance,
-  WatchHost,
-  Webpack
+  WatchHost
 } from './interfaces';
 import * as logger from './logger';
 import { makeResolver } from './resolver';
@@ -29,7 +29,7 @@ export interface ServiceHostWhichMayBeCacheable {
 export function makeServicesHost(
   scriptRegex: RegExp,
   log: logger.Logger,
-  loader: Webpack,
+  loader: webpack.loader.LoaderContext,
   instance: TSInstance,
   enableFileCaching: boolean,
   projectReferences?: ReadonlyArray<typescript.ProjectReference>
@@ -232,7 +232,7 @@ function makeResolvers(
 export function makeWatchHost(
   scriptRegex: RegExp,
   log: logger.Logger,
-  loader: Webpack,
+  loader: webpack.loader.LoaderContext,
   instance: TSInstance,
   projectReferences?: ReadonlyArray<typescript.ProjectReference>
 ) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as micromatch from 'micromatch';
 import * as path from 'path';
 import * as typescript from 'typescript';
+import * as webpack from 'webpack';
 
 import constants = require('./constants');
 import {
@@ -12,7 +13,6 @@ import {
   ReverseDependencyGraph,
   Severity,
   TSInstance,
-  Webpack,
   WebpackError,
   WebpackModule
 } from './interfaces';
@@ -325,7 +325,7 @@ function getProjectReferenceForFile(filePath: string, instance: TSInstance) {
 
 export function validateSourceMapOncePerProject(
   instance: TSInstance,
-  loader: Webpack,
+  loader: webpack.loader.LoaderContext,
   jsFileName: string,
   project: typescript.ResolvedProjectReference
 ) {
@@ -397,7 +397,7 @@ function getOutputJavaScriptFileName(
     ? '.json'
     : constants.tsxRegex.test(inputFileName) &&
       options.jsx === typescript.JsxEmit.Preserve
-      ? '.jsx'
-      : '.js';
+    ? '.jsx'
+    : '.js';
   return outputPath.replace(constants.extensionRegex, newExtension);
 }

--- a/src/watch-run.ts
+++ b/src/watch-run.ts
@@ -1,7 +1,8 @@
 import * as path from 'path';
+import * as webpack from 'webpack';
 
 import * as constants from './constants';
-import { TSFile, TSInstance, WebpackCompiler } from './interfaces';
+import { TSFile, TSInstance } from './interfaces';
 import { readFile } from './utils';
 
 /**
@@ -12,7 +13,7 @@ export function makeWatchRun(instance: TSInstance) {
   const lastTimes = new Map<string, number>();
   const startTime = 0;
 
-  return (compiler: WebpackCompiler, callback: () => void) => {
+  return (compiler: webpack.Compiler, callback: () => void) => {
     if (null === instance.modifiedFiles) {
       instance.modifiedFiles = new Map<string, TSFile>();
     }

--- a/test/execution-tests/option-context/yarn.lock
+++ b/test/execution-tests/option-context/yarn.lock
@@ -11,10 +11,9 @@
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.2.tgz#6ae4d8740c0da5d5a627df725b4eed71b8e36668"
 
 "@types/node@*":
-  version "8.0.54"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.54.tgz#3fd9357db4af388b79e03845340259440edffde6"
-  dependencies:
-    "@types/events" "*"
+  version "11.13.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.8.tgz#e5d71173c95533be9842b2c798978f095f912aab"
+  integrity sha512-szA3x/3miL90ZJxUCzx9haNbK5/zmPieGraZEe4WI+3srN0eGLiT22NXeMHmyhNEopn+IrxqMc7wdVwvPl8meg==
 
 "@types/react-dom@^16.0.3":
   version "16.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,11 +29,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.8.tgz#e5d71173c95533be9842b2c798978f095f912aab"
   integrity sha512-szA3x/3miL90ZJxUCzx9haNbK5/zmPieGraZEe4WI+3srN0eGLiT22NXeMHmyhNEopn+IrxqMc7wdVwvPl8meg==
 
-"@types/node@^10.0.0":
-  version "10.12.25"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.25.tgz#0d01a7dd6127de60d861ece4a650963042abb538"
-  integrity sha512-IcvnGLGSQFDvC07Bz2I8SX+QKErDZbUdiQq7S2u3XyzTyJfUmT0sWJMbeQkMzpTAkO7/N7sZpW/arUM2jfKsbQ==
-
 "@types/semver@^5.4.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,10 +45,10 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/webpack@^4.4.27":
-  version "4.4.27"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.4.27.tgz#8bb9429185977a6b3b9e6e6132f561066aa7e7c2"
-  integrity sha512-xSll/4UXnLQ0xjdAoTRIFxA6NPC2abJ8nHxRH6SqTymHrfGCc8er7qH0npwCP8q3VFoJh2Hjz1wH8oTjwx9/jQ==
+"@types/webpack@^4.4.29":
+  version "4.4.29"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.4.29.tgz#d2a1c1d8c071b06521d32cee1c6b33d704b54b2c"
+  integrity sha512-8KVp+cNy9OPYsa4jU6vWsBemn5ixJ0Durh95Cw/YpEKm5ks2ODhdXc4FG3Xc46KIbPrJolwY7mSZFNn1aU3hKg==
   dependencies:
     "@types/anymatch" "*"
     "@types/node" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@types/anymatch@*":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
+  integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
 "@types/braces@*":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-2.3.0.tgz#d00ec0a76562b2acb6f29330be33a093e33ed25c"
@@ -19,6 +24,11 @@
   dependencies:
     "@types/braces" "*"
 
+"@types/node@*":
+  version "11.13.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.8.tgz#e5d71173c95533be9842b2c798978f095f912aab"
+  integrity sha512-szA3x/3miL90ZJxUCzx9haNbK5/zmPieGraZEe4WI+3srN0eGLiT22NXeMHmyhNEopn+IrxqMc7wdVwvPl8meg==
+
 "@types/node@^10.0.0":
   version "10.12.25"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.25.tgz#0d01a7dd6127de60d861ece4a650963042abb538"
@@ -27,6 +37,29 @@
 "@types/semver@^5.4.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
+
+"@types/tapable@*":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
+  integrity sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==
+
+"@types/uglify-js@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.0.4.tgz#96beae23df6f561862a830b4288a49e86baac082"
+  integrity sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==
+  dependencies:
+    source-map "^0.6.1"
+
+"@types/webpack@^4.4.27":
+  version "4.4.27"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.4.27.tgz#8bb9429185977a6b3b9e6e6132f561066aa7e7c2"
+  integrity sha512-xSll/4UXnLQ0xjdAoTRIFxA6NPC2abJ8nHxRH6SqTymHrfGCc8er7qH0npwCP8q3VFoJh2Hjz1wH8oTjwx9/jQ==
+  dependencies:
+    "@types/anymatch" "*"
+    "@types/node" "*"
+    "@types/tapable" "*"
+    "@types/uglify-js" "*"
+    source-map "^0.6.0"
 
 "@webassemblyjs/ast@1.7.8":
   version "1.7.8"
@@ -4413,7 +4446,7 @@ source-map@0.5.x, source-map@^0.5.6, source-map@^0.5.7:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 


### PR DESCRIPTION
Some tidy up of the internals to use the `@types/webpack` webpack package for webpack specific typings. 

As far as I can see there are two bugs in the webpack typings which I'll try and upstream: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/35053