### PR TITLE
Improve debugging experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 bundle.js
 npm-debug.log
 /.test/
-/.vscode/
 /test/execution-tests/**/typings
 !/test/**/expectedOutput-*/**
 /**/node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,4 @@ CONTRIBUTING.md
 Dockerfile
 HISTORY.md
 RELEASING.md
+*.js.map

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run open execution test",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run",
+        "execution-tests",
+        "--",
+        "--single-test",
+        "${fileDirname}",
+        "--debug"
+      ],
+      "console": "integratedTerminal",
+      "port": 5858
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,22 @@
       ],
       "console": "integratedTerminal",
       "port": 5858
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run open comparison test",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run",
+        "comparison-tests",
+        "--",
+        "--single-test",
+        "${fileDirname}",
+        "--debug"
+      ],
+      "console": "integratedTerminal",
+      "port": 5858
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,27 @@ To read about the execution test pack take a look [here](test/execution-tests/RE
 
 ## Debugging
 
-To debug ts-loader itself:
+### Debugging tests
 
-```
+If you’re using VS Code, set breakpoints anywhere in `src`. Open any file inside the comparison test or execution test you want to debug, then, in the debug pane, select “Run open comparison test” or “Run open execution test.”
+
+If you’re not using VS Code, simply adding `--debug` to either a `yarn run comparison-tests` or `yarn run execution-tests` will pause before each test (this is best combined with `--single-test`), allowing you to attach to the node process on port 5858 with your favorite debugger.
+
+### Debugging ts-loader installed from npm in your own Webpack project
+
+```sh
 node --inspect-brk node_modules/webpack/bin/webpack.js --config webpack.dev.js # Obviously configure this depending upon your project setup
 ```
 
 Then put a breakpoint in `node_modules/ts-loader/dist/index.js`, and debug in VS Code with "Attach to Node Process". The dist is JS compiled from TS, but it’s still pretty readable.
+
+### Debugging a local, cloned copy of ts-loader in your own Webpack project
+
+Just like the steps above, except substituting a local copy of ts-loader for the one in node_modules:
+
+1. In `ts-loader`, run `yarn build`
+2. Still in `ts-loader`, run `npm link`
+3. In your own Webpack project directory, run `npm link ts-loader`. There’s now a chain of symlinks from `node_modules/ts-loader` to your cloned copy built from source.
+4. Repeat the steps above in “Debugging ts-loader installed from npm...” except now, you can take advantage of source maps, so you can set breakpoints in `ts-loader/src` instead of `ts-loader/dist`.
+5. If you want to try making changes to `ts-loader`, make changes and then repeat steps 1 and 4—no need to re-run the `npm link` steps.
+6. Run `npm unlink ts-loader` in your own project directory to remove the symlink when you’re done.

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -10,6 +10,7 @@
     "moduleResolution": "node",
     "declaration": true,
     "outDir": "../dist",
-    "declarationDir": "../dist/types"
+    "declarationDir": "../dist/types",
+    "sourceMap": true
   }
 }

--- a/test/comparison-tests/README.md
+++ b/test/comparison-tests/README.md
@@ -75,3 +75,7 @@ patch0 is applied:
 ## Flaky tests
 
 Some of the tests in the pack are flaky.  For the most part the failures they occasionally experience are not significant.  If you want a test to be allowed to fail without failing the overall build whilst still seeing the output then place a file with the name `_FLAKY_` in the root of that particular test.
+
+## Debugging
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md#debugging).

--- a/test/execution-tests/README.md
+++ b/test/execution-tests/README.md
@@ -58,3 +58,5 @@ It's pretty handy to be able to debug tests; for that reason you can run a singl
 `yarn run execution-tests -- --single-test nameOfTest --watch`
 
 Then you can fire up http://localhost:9876/ and the world's your oyster.
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md#debugging) for more information on debugging.

--- a/test/execution-tests/run-tests.js
+++ b/test/execution-tests/run-tests.js
@@ -90,7 +90,22 @@ function isNotBabelTest (testName) {
     return true;
 }
 
+function getTestNameFromPath (testNameOrPath) {
+    var tsLoaderPath = path.resolve(__dirname, '../..');
+    var tsLoaderBasename = path.basename(tsLoaderPath);
+    var executionTestsRelativeRoot = path.relative(tsLoaderPath, __dirname);
+    var executionTestsAbsoluteRoot = path.join(tsLoaderPath, executionTestsRelativeRoot);
+    // It wasn’t a path in execution-tests; assume it was a test name
+    if (testNameOrPath.indexOf(path.join(tsLoaderBasename, executionTestsRelativeRoot)) === -1) {
+        return testNameOrPath;
+    }
+    // E.g. 3.0.1_projectReferences/lib/index.ts
+    var testPathRelativeToExecutionTests = path.relative(executionTestsAbsoluteRoot, testNameOrPath);
+    return testPathRelativeToExecutionTests.split(path.sep)[0];
+}
+
 function runTests(testName) {
+    testName = getTestNameFromPath(testName);
     console.log('\n-------------------------------------------------------------------------\n');
     console.log('RUNNING THIS TEST SUITE: ' + testName +'\n\n');
 
@@ -103,6 +118,7 @@ function runTests(testName) {
     }
 
     var karmaConfPath = path.join(testPath, 'karma.conf.js');
+    var debug = process.argv.indexOf('--debug') > -1;
 
     if (pathExists(path.join(testPath, 'shrinkwrap.yaml'))) {
         console.log('npx pnpm install into ' + testPath);
@@ -113,9 +129,11 @@ function runTests(testName) {
     }
 
     try {
-        if (pathExists(path.join(testPath, 'karma.conf.js'))) {
+        if (pathExists(karmaConfPath)) {
+            var karmaPath = path.resolve(__dirname, '../../node_modules/karma/bin/karma');
             var singleRunOrWatch = watch ? '' : ' --single-run';
-            execSync('karma start --reporters mocha' + singleRunOrWatch + ' --browsers ChromeHeadlessNoSandbox', { cwd: testPath, stdio: 'inherit' });
+            var program = debug ? 'node --inspect-brk=5858 ' + karmaPath : 'karma';
+            execSync(program + ' start --reporters mocha' + singleRunOrWatch + ' --browsers ChromeHeadlessNoSandbox', { cwd: testPath, stdio: 'inherit' });
 
             passingTests.push(testName);
         } else {

--- a/test/execution-tests/run-tests.js
+++ b/test/execution-tests/run-tests.js
@@ -138,7 +138,9 @@ function runTests(testName) {
             passingTests.push(testName);
         } else {
             console.log('running webpack compilation');
-            execSync('webpack --bail', { cwd: testPath, stdio: 'inherit' });
+            var webpackPath = path.resolve(__dirname, '../../node_modules/webpack/bin/karma');
+            var program = debug ? 'node --inspect-brk=5858 ' + webpackPath : 'webpack';
+            execSync(webpackPath + ' --bail', { cwd: testPath, stdio: 'inherit' });
             passingTests.push(testName);
         }
     }

--- a/test/execution-tests/run-tests.js
+++ b/test/execution-tests/run-tests.js
@@ -138,7 +138,7 @@ function runTests(testName) {
             passingTests.push(testName);
         } else {
             console.log('running webpack compilation');
-            var webpackPath = path.resolve(__dirname, '../../node_modules/webpack/bin/karma');
+            var webpackPath = path.resolve(__dirname, '../../node_modules/webpack/bin/webpack.js');
             var program = debug ? 'node --inspect-brk=5858 ' + webpackPath : 'webpack';
             execSync(webpackPath + ' --bail', { cwd: testPath, stdio: 'inherit' });
             passingTests.push(testName);


### PR DESCRIPTION
- Turns on source maps (excludes them from files published to npm)
- Adds `--debug` switch to run-tests.js in execution-tests and comparison-tests
- Adds configurations for VS Code to debug the currently open execution test or comparison test
- Updates docs accordingly

It's a miracle, @johnnyreilly, it even works on Windows 😛 

![debugging-windows](https://user-images.githubusercontent.com/3277153/57574977-cd002a80-73f6-11e9-9c5c-a22a1dd80dae.PNG)


<details>
<summary>Proof that source maps are excluded from npm:</summary>

```
$ npm pack
npm notice 
npm notice 📦  ts-loader@6.0.0
npm notice === Tarball Contents === 
npm notice 2.8kB  package.json                 
npm notice 23.3kB CHANGELOG.md                 
npm notice 879B   HISTORY.md                   
npm notice 57B    index.js                     
npm notice 1.1kB  LICENSE                      
npm notice 31.1kB README.md                    
npm notice 8.4kB  dist/after-compile.js        
npm notice 2.6kB  dist/compilerSetup.js        
npm notice 3.6kB  dist/config.js               
npm notice 743B   dist/constants.js            
npm notice 14.2kB dist/index.js                
npm notice 9.8kB  dist/instances.js            
npm notice 115B   dist/interfaces.js           
npm notice 1.9kB  dist/logger.js               
npm notice 331B   dist/resolver.js             
npm notice 16.8kB dist/servicesHost.js         
npm notice 257B   dist/types/after-compile.d.ts
npm notice 504B   dist/types/compilerSetup.d.ts
npm notice 796B   dist/types/config.d.ts       
npm notice 694B   dist/types/constants.d.ts    
npm notice 361B   dist/types/index.d.ts        
npm notice 793B   dist/types/instances.d.ts    
npm notice 5.3kB  dist/types/interfaces.d.ts   
npm notice 433B   dist/types/logger.d.ts       
npm notice 163B   dist/types/resolver.d.ts     
npm notice 918B   dist/types/servicesHost.d.ts 
npm notice 2.8kB  dist/types/utils.d.ts        
npm notice 265B   dist/types/watch-run.d.ts    
npm notice 11.3kB dist/utils.js                
npm notice 2.0kB  dist/watch-run.js            
npm notice === Tarball Details === 
npm notice name:          ts-loader                               
npm notice version:       6.0.0                                   
npm notice filename:      ts-loader-6.0.0.tgz                     
npm notice package size:  39.0 kB                                 
npm notice unpacked size: 144.3 kB                                
npm notice shasum:        20c3884bc60b9cc5f24895b01b9abd9a519c2719
npm notice integrity:     sha512-CMfmvWZfh3xko[...]Bf5/xst3LhnVg==
npm notice total files:   30                                      
npm notice 
ts-loader-6.0.0.tgz
```
</details>