### PR TITLE
Fix type reference directive resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v6.0.1
+
+* [Fix issue with `resolveTypeReferenceDirective` causing errors like `Cannot find name 'it'` with Jest](https://github.com/TypeStrong/ts-loader/pull/936) (#934) (#919) - thanks @andrewbranch!
+
 ## v6.0.0
 
 * [Drop support for node < 8.6 related to micromatch upgrade to 4](https://github.com/TypeStrong/ts-loader/pull/930); see: https://github.com/TypeStrong/ts-loader/issues/929

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist/types/index.d.ts",


### PR DESCRIPTION
Fixes #934 
Fixes #919 

There was really no way to know this without debugging, but getting default typeRoots for a project doesn't work if the module resolution host doesn't implement `getCurrentDirectory()`. Arguably the language service API shouldn’t treat it as optional, or should emit a warning if it’s missing, or fall back to the default from `ts.sys` (maybe I'll bring this up to Sheetal, but it certainly wouldn't land until 3.6), but I think a good policy for ts-loader would be to implement _all_ members of any kind of Host, especially if it’s as easy a just including things from `ts.sys`. It _is_ kind of misleading because there are other places (I think `CompilerHost` is an example) where missing optional members get filled in with good defaults.