### PR TITLE
Throw error if a file not in the TS project is found

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,14 +4,9 @@ import * as semver from 'semver';
 import * as typescript from 'typescript';
 import * as webpack from 'webpack';
 
-import { LoaderOptions, WebpackError } from './interfaces';
+import { ConfigFile, LoaderOptions, WebpackError } from './interfaces';
 import * as logger from './logger';
 import { formatErrors } from './utils';
-
-interface ConfigFile {
-  config?: any;
-  error?: typescript.Diagnostic;
-}
 
 export function getConfigFile(
   compiler: typeof typescript,

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,6 +423,17 @@ function updateFileInCache(
     instance.changedFilesList = true;
   }
 
+  // instance.version must be increased when a new root file is added.
+  //
+  // Note that the file could actually be in the cache if it was found
+  // as a dependency before.
+  //
+  // See https://github.com/TypeStrong/ts-loader/issues/943
+  //
+  if (!instance.rootFileNames.has(filePath)) {
+    instance.version!++;
+  }
+
   if (instance.watchHost !== undefined && contents === undefined) {
     fileWatcherEventKind = instance.compiler.FileWatcherEventKind.Deleted;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,8 +79,16 @@ function successLoader(
     instance
   );
 
-  if (changedFilesList) {
+  if (changedFilesList && !instance.rootFileNames.has(filePath)) {
     reloadRootFileNamesFromConfig(loaderContext, instance);
+    if (
+      !instance.rootFileNames.has(filePath) &&
+      !options.onlyCompileBundledFiles
+    ) {
+      throw new Error(
+        `The file ${filePath} is not part of the project specified in tsconfig.json. Make sure it is covered by the fields 'include', 'exclude' and 'files'.`
+      );
+    }
   }
 
   const referencedProject = getAndCacheProjectReference(filePath, instance);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,6 +3,11 @@ import * as typescript from 'typescript';
 
 import { Chalk } from 'chalk';
 
+export interface ConfigFile {
+  config?: any;
+  error?: typescript.Diagnostic;
+}
+
 export interface ErrorInfo {
   code: number;
   severity: Severity;
@@ -55,6 +60,10 @@ export interface TSInstance {
   /** Used for Vue for the most part */
   appendTsTsxSuffixesIfRequired: (filePath: string) => string;
   loaderOptions: LoaderOptions;
+
+  basePath: string;
+  configFile: ConfigFile;
+  configFilePath: string | undefined;
   /**
    * Root files as specified by tsconfig.json' include/exclude/files
    */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -56,6 +56,10 @@ export interface TSInstance {
   appendTsTsxSuffixesIfRequired: (filePath: string) => string;
   loaderOptions: LoaderOptions;
   /**
+   * Root files as specified by tsconfig.json' include/exclude/files
+   */
+  rootFileNames: Set<string>;
+  /**
    * a cache of all the files
    */
   files: TSFiles;

--- a/test/comparison-tests/appendSuffixTo/tsconfig.json
+++ b/test/comparison-tests/appendSuffixTo/tsconfig.json
@@ -1,4 +1,7 @@
 {
 	"compilerOptions": {
-	}
+	},
+    "files": [
+        "index.vue.ts"
+    ]
 }

--- a/test/comparison-tests/basic/tsconfig.json
+++ b/test/comparison-tests/basic/tsconfig.json
@@ -3,6 +3,8 @@
 		
 	},
 	"files": [
-		"lib/externalLib.d.ts"
+	    "lib/externalLib.d.ts",
+        "submodule/submodule.ts",
+        "app.ts",
 	]
 }

--- a/test/comparison-tests/codeSplitting/tsconfig.json
+++ b/test/comparison-tests/codeSplitting/tsconfig.json
@@ -1,8 +1,5 @@
 {
 	"compilerOptions": {
 		
-	},
-	"files": [
-		"require.d.ts"
-	]
+	}
 }

--- a/test/comparison-tests/conditionalRequire/tsconfig.json
+++ b/test/comparison-tests/conditionalRequire/tsconfig.json
@@ -1,9 +1,5 @@
 {
 	"compilerOptions": {
 		
-	},
-	"files": [
-		"require.d.ts",
-		"globals.d.ts"
-	]
+	}
 }

--- a/test/comparison-tests/declarationDeps/tsconfig.json
+++ b/test/comparison-tests/declarationDeps/tsconfig.json
@@ -1,5 +1,3 @@
 {
-    "files": [
-        "./references.d.ts"
-    ]
+
 }

--- a/test/comparison-tests/declarationWatch/tsconfig.json
+++ b/test/comparison-tests/declarationWatch/tsconfig.json
@@ -3,6 +3,8 @@
 		
 	},
 	"files": [
-		"thing.d.ts"
+	    "thing.d.ts",
+        "app.ts",
+        "dep.ts"
 	]
 }

--- a/test/comparison-tests/es6codeSplitting/tsconfig.json
+++ b/test/comparison-tests/es6codeSplitting/tsconfig.json
@@ -2,8 +2,5 @@
 	"compilerOptions": {
 		"target": "es5",
 		"module": "commonjs"
-	},
-	"files": [
-		"require.d.ts"
-	]
+	}
 }

--- a/test/comparison-tests/externals/tsconfig.json
+++ b/test/comparison-tests/externals/tsconfig.json
@@ -1,5 +1,2 @@
 {
-	"files": [
-		"hello.d.ts"
-	]
 }

--- a/test/comparison-tests/localTsImplementationOfTypings/tsconfig.json
+++ b/test/comparison-tests/localTsImplementationOfTypings/tsconfig.json
@@ -3,6 +3,7 @@
 		
 	},
 	"include": [
-		"app.ts"
+        "app.ts",
+        "fake.ts"
 	]
 }

--- a/test/comparison-tests/nodeModulesMeaningfulErrorWhenImportingTs/tsconfig.json
+++ b/test/comparison-tests/nodeModulesMeaningfulErrorWhenImportingTs/tsconfig.json
@@ -1,5 +1,8 @@
 {
 	"compilerOptions": {
-		
+	    "include": [
+            "node_modules",
+            "app.ts"
+        ]
 	}
 }

--- a/test/comparison-tests/npmLink/tsconfig.json
+++ b/test/comparison-tests/npmLink/tsconfig.json
@@ -3,7 +3,8 @@
 		"module": "commonjs"
 	},
 	// so that ts files there is part of this ts project
-	"include": [
+    "include": [
+        "app.ts",
 		"../../test/comparison-tests/testLib/*"
 	]
 }

--- a/test/comparison-tests/tsconfigSearch/tsconfig.json
+++ b/test/comparison-tests/tsconfigSearch/tsconfig.json
@@ -1,5 +1,2 @@
 {
-    "files": [
-        "lib/externalLib.d.ts"
-    ]
 }


### PR DESCRIPTION
This pull request keeps track of the project's root filenames and uses it to increase the `instance.version` when required, solving #943.

Additionally, it will throw an error like

```
Error: The file /Users/davazp/Projects/.../analytics.ts is not part of the project specified in tsconfig.json. Make sure it is covered by the fields 'include', 'exclude' and 'files'.
    at successLoader (/Users/davazp/Projects/ts-loader/dist/index.js:70:19)
    at Timeout.retry [as _onTimeout] (/Users/davazp/Projects/ts-loader/dist/index.js:35:13)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10)
```

when such a file is found and `onlyCompileBundledFiles` is `false`. This second behaviour is not mandatory to solve the issue, but I think it is desirable to ensure the project would work with `tsc` as well by default.


## Summary of changes:

- Add `rootFileNames` to TSInstance. This property gets initialized when the instance is created and updated on new files.

- Add `configFile` and `configFilePath` to `TSInstance` to make sure the same snapshot of tsconfig is always used to get the new list of root files.

- On new root files, call `reloadRootFileNamesFromConfig` which will recall `getConfigParseResult`, and so it will read files from the project, and use it to update `rootFileNames`. 

- If a file passed to the loader is not a root file name, and `onlyCompileBundledFiles` is false, throw an error. As this file is not covered by tsconfig.json.

- If a new root file name is found, increase the instance version, to solve #943 .
