### PR TITLE
Fix: Increase the instance version when new root files are found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v6.0.4
+* [Fix issue when handling files not included in tsconfig.json](https://github.com/TypeStrong/ts-loader/issues/943) (#934) - thanks @davazp!
+
 ## v6.0.3
 * [Upgrade typescript version to 3.5.2](https://github.com/TypeStrong/ts-loader/pull/954) (#954) - thanks @fa93hws
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist/types/index.d.ts",

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -125,6 +125,7 @@ function successfulTypeScriptInstance(
   }
 
   const compilerOptions = getCompilerOptions(configParseResult);
+  const rootFileNames = new Set<string>();
   const files: TSFiles = new Map<string, TSFile>();
   const otherFiles: TSFiles = new Map<string, TSFile>();
 
@@ -200,6 +201,7 @@ function successfulTypeScriptInstance(
       compilerOptions,
       appendTsTsxSuffixesIfRequired,
       loaderOptions,
+      rootFileNames,
       files,
       otherFiles,
       program,
@@ -226,6 +228,7 @@ function successfulTypeScriptInstance(
         text: fs.readFileSync(normalizedFilePath, 'utf-8'),
         version: 0
       });
+      rootFileNames.add(normalizedFilePath);
     });
   } catch (exc) {
     return {
@@ -249,6 +252,7 @@ function successfulTypeScriptInstance(
     compilerOptions,
     appendTsTsxSuffixesIfRequired,
     loaderOptions,
+    rootFileNames,
     files,
     otherFiles,
     languageService: null,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -55,6 +55,7 @@ export interface TSInstance {
   /** Used for Vue for the most part */
   appendTsTsxSuffixesIfRequired: (filePath: string) => string;
   loaderOptions: LoaderOptions;
+  rootFileNames: Set<string>;
   /**
    * a cache of all the files
    */


### PR DESCRIPTION
This is a minimal fix for #943.

When a new root file is processed, ensure that the instance version is increased. 

It is an alternative to the bigger PR #945.