### PR TITLE
Add output path to vanilla example webpack config

### DIFF
--- a/examples/vanilla/webpack.config.js
+++ b/examples/vanilla/webpack.config.js
@@ -1,8 +1,13 @@
 'use strict';
+const path = require('path');
 
 module.exports = {
     devtool: 'inline-source-map',
-    entry: './src/index.ts',
+	entry: './src/index.ts',
+	output: {
+		filename: 'main.js',
+		path: path.resolve(__dirname, 'dist')
+	},
     module: {
         rules: [
             {


### PR DESCRIPTION
The webpack-dev-server uses the root path not the dist folder, so a specific output folder config is needed for the yarn watch command to work.