### PR TITLE
fixes https://github.com/TypeStrong/ts-loader/issues/1014

### DIFF
--- a/src/instances.ts
+++ b/src/instances.ts
@@ -567,7 +567,7 @@ export function isReferencedFile(instance: TSInstance, filePath: string) {
 }
 
 export function getEmitOutput(instance: TSInstance, filePath: string) {
-  if (fileExtensionIs(filePath, typescript.Extension.Dts)) {
+  if (fileExtensionIs(filePath, instance.compiler.Extension.Dts)) {
     return [];
   }
   const program = ensureProgram(instance);

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -507,7 +507,11 @@ function getOutputFileNames(
     }
     if (
       (configFile.options.declaration || configFile.options.composite) &&
-      (instance.compiler as any).hasTSFileExtension(inputFileName)
+      (instance.compiler as any).hasTSFileExtension(inputFileName) &&
+      !(instance.compiler as any).fileExtensionIs(
+        inputFileName,
+        typescript.Extension.Dts
+      )
     ) {
       const dts = (instance.compiler as any).getOutputDeclarationFileName(
         inputFileName,

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -507,11 +507,7 @@ function getOutputFileNames(
     }
     if (
       (configFile.options.declaration || configFile.options.composite) &&
-      (instance.compiler as any).hasTSFileExtension(inputFileName) &&
-      !(instance.compiler as any).fileExtensionIs(
-        inputFileName,
-        typescript.Extension.Dts
-      )
+      (instance.compiler as any).hasTSFileExtension(inputFileName)
     ) {
       const dts = (instance.compiler as any).getOutputDeclarationFileName(
         inputFileName,
@@ -571,6 +567,9 @@ export function isReferencedFile(instance: TSInstance, filePath: string) {
 }
 
 export function getEmitOutput(instance: TSInstance, filePath: string) {
+  if (fileExtensionIs(filePath, typescript.Extension.Dts)) {
+    return [];
+  }
   const program = ensureProgram(instance);
   if (program !== undefined) {
     const sourceFile = program.getSourceFile(filePath);


### PR DESCRIPTION
it seems that ts-loader is  trying to emit declaration files for a declaration file, this causes typescript's getOutputDeclarationFileName throw an error