### PR TITLE
Output types alongside JS files, enable declaration maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v6.2.1
+* [Output types alongside JS files, enable declaration maps](https://github.com/TypeStrong/ts-loader/pull/1026) - thanks @meyer!
+
 ## v6.2.0
 * [Emitting .tsbuildinfo when using watch api](https://github.com/TypeStrong/ts-loader/pull/1017) - thanks @sheetalkamat!
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ts-loader",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist",
   "scripts": {
     "build": "tsc --version && tsc --project \"./src\"",
     "lint": "tslint --project \"./src\"",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -10,7 +10,8 @@
     "moduleResolution": "node",
     "declaration": true,
     "outDir": "../dist",
-    "declarationDir": "../dist/types",
+    "declarationDir": "../dist",
+    "declarationMap": true,
     "sourceMap": true
   }
 }


### PR DESCRIPTION
This PR sets the type declaration output directory to be the same as the JS output directory so that types are automatically pulled in for folks who are requiring things from `dist`.

I’ve been spelunking around in the internals of `ts-loader` to see how I can get access to the compiler/checker. I’ve had to use a `yarn link`’d copy of `ts-loader` with the change contained in this PR because types aren’t matching up for files in `dist`. 

While I was at it, I enabled declaration maps too.

Current (hella nasty) workaround:

```typescript
const { getTypeScriptInstance } = require('ts-loader/dist/instances') as typeof import('ts-loader/dist/types/instances');
const tsLoader = require('ts-loader') as typeof import('ts-loader/dist/types/index');
```