### PR TITLE
Fixed compiler options typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 /*.js
 !index.js
 /src/*.js

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/TypeStrong/ts-loader",
   "dependencies": {
-    "@moebius/ts-compiler-options": "^1.1.0",
+    "@moebius/ts-compiler-options": "^1.2.0",
     "chalk": "^2.3.0",
     "enhanced-resolve": "^4.0.0",
     "loader-utils": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "homepage": "https://github.com/TypeStrong/ts-loader",
   "dependencies": {
+    "@moebius/ts-compiler-options": "^1.1.0",
     "chalk": "^2.3.0",
     "enhanced-resolve": "^4.0.0",
     "loader-utils": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/TypeStrong/ts-loader",
   "dependencies": {
-    "@moebius/ts-compiler-options": "^1.2.0",
+    "@moebius/ts-compiler-options": "^1.2.1",
     "chalk": "^2.3.0",
     "enhanced-resolve": "^4.0.0",
     "loader-utils": "^1.0.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { convertCompilerOptions } from '@moebius/ts-compiler-options';
 import { Chalk } from 'chalk';
 import * as path from 'path';
 import * as semver from 'semver';
@@ -159,9 +160,16 @@ export function getParsedCommandLine(
   loaderOptions: LoaderOptions,
   configFilePath: string
 ): typescript.ParsedCommandLine | undefined {
+  // Converting compiler options from external format
+  // to the one required by TypeScript
+  const internalCompilerOptions = convertCompilerOptions(
+    'external-to-internal',
+    loaderOptions.compilerOptions
+  );
+
   const result = compiler.getParsedCommandLineOfConfigFile(
     configFilePath,
-    loaderOptions.compilerOptions,
+    internalCompilerOptions,
     {
       ...compiler.sys,
       onUnRecoverableConfigFileDiagnostic: () => {} // tslint:disable-line no-empty

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,7 +1,26 @@
-export { ModuleResolutionHost, FormatDiagnosticsHost } from 'typescript';
+import { Chalk } from 'chalk';
 import * as typescript from 'typescript';
 
-import { Chalk } from 'chalk';
+/**
+ * Importing custom compiler options types,
+ * because TypeScript doesn't provide correct ones
+ *
+ * See: https://github.com/TypeStrong/ts-loader/issues/962
+ */
+import { CompilerOptions } from '@moebius/ts-compiler-options';
+
+export { ModuleResolutionHost, FormatDiagnosticsHost } from 'typescript';
+
+// Re-exporting compiler options types
+export {
+  CompilerOptions,
+  EnumFields,
+  JsxEmit,
+  ModuleKind,
+  ModuleResolutionKind,
+  NewLineKind,
+  ScriptTarget
+} from '@moebius/ts-compiler-options';
 
 export interface ErrorInfo {
   code: number;
@@ -196,7 +215,7 @@ export interface LoaderOptions {
   errorFormatter: (message: ErrorInfo, colors: Chalk) => string;
   onlyCompileBundledFiles: boolean;
   colors: boolean;
-  compilerOptions: typescript.CompilerOptions;
+  compilerOptions: CompilerOptions;
   appendTsSuffixTo: RegExp[];
   appendTsxSuffixTo: RegExp[];
   happyPackMode: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,6 +25,11 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@moebius/ts-compiler-options@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@moebius/ts-compiler-options/-/ts-compiler-options-1.2.0.tgz#9bc68a86b4c18eed764a007d9aa1bfcd9671808d"
+  integrity sha512-9UwioBXWjtqVKm1F9T57K8gt94WmEzOiobzT6JGKWldIUo4SfU6x/IDNsK0fTE1bM6BxkaOnO+jAWjzr3KLvtA==
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,10 +25,12 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@moebius/ts-compiler-options@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@moebius/ts-compiler-options/-/ts-compiler-options-1.2.0.tgz#9bc68a86b4c18eed764a007d9aa1bfcd9671808d"
-  integrity sha512-9UwioBXWjtqVKm1F9T57K8gt94WmEzOiobzT6JGKWldIUo4SfU6x/IDNsK0fTE1bM6BxkaOnO+jAWjzr3KLvtA==
+"@moebius/ts-compiler-options@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@moebius/ts-compiler-options/-/ts-compiler-options-1.2.1.tgz#b1aebc57fad9b2d9d9e1fe898730f733cece2c12"
+  integrity sha512-EONuuNVkh6Gn1fkwZT58uTHLH9g30uGSeaFVMnTS7ZMWsHvi4qxN3bZfnX8DWulgryp1sDUwdkW6hxF/VStgvg==
+  dependencies:
+    tslib "^1.10.0"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
@@ -5289,6 +5291,11 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
+tslib@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"


### PR DESCRIPTION
TypeScript declarations doesn't provide proper types for `CompilerOptions` that can be used to describe content of `tsconfig.json` file, instead, they provide internal representation of CompilerOptions, where enum values must be specified using numbers instead of strings.

I've created a [custom package](https://github.com/moebius-mlm/ts-compiler-options) that exports `CompilerOptions` in the format [described in TypeScript documentation](https://www.typescriptlang.org/docs/handbook/compiler-options.html).

This PR replaces `CompilerOptions` types from `typescript` to [`@moebius/ts-compiler-options`](https://github.com/moebius-mlm/ts-compiler-options). This should effectively fix typing issues discussed in #962.