### PR TITLE
Expose loader context to custom transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v6.2.2
+* [Expose loader context to custom transformer](https://github.com/TypeStrong/ts-loader/pull/1040) - thanks @xbtsw!
+
 ## v6.2.1
 * [Output types alongside JS files, enable declaration maps](https://github.com/TypeStrong/ts-loader/pull/1026) - thanks @meyer!
 

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Also, if you are using `thread-loader` in watch mode, remember to set `poolTimeo
 
 These options should be functions which will be used to resolve the import statements and the `<reference types="...">` directives instead of the default TypeScript implementation. It's not intended that these will typically be used by a user of `ts-loader` - they exist to facilitate functionality such as [Yarn Plug’n’Play](https://yarnpkg.com/en/docs/pnp).
 
-#### getCustomTransformers _( (program: Program) => { before?: TransformerFactory<SourceFile>[]; after?: TransformerFactory<SourceFile>[]; } )_
+#### getCustomTransformers _( (program: Program, loaderContext: webpack.loader.LoaderContext) => { before?: TransformerFactory<SourceFile>[]; after?: TransformerFactory<SourceFile>[]; } )_
 
 Provide custom transformers - only compatible with TypeScript 2.3+ (and 2.4 if using `transpileOnly` mode). For example usage take a look at [typescript-plugin-styled-components](https://github.com/Igorbek/typescript-plugin-styled-components) or our [test](test/comparison-tests/customTransformer).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -232,7 +232,7 @@ function successfulTypeScriptInstance(
       );
       loader._module.errors.push(...solutionErrors, ...errors);
     }
-    transpileInstance.transformers = getCustomTransformers(program);
+    transpileInstance.transformers = getCustomTransformers(program, loader);
     return { instance: transpileInstance };
   }
 
@@ -310,7 +310,7 @@ function successfulTypeScriptInstance(
     instance.builderProgram = instance.watchOfFilesAndCompilerOptions.getProgram();
     instance.program = instance.builderProgram.getProgram();
 
-    instance.transformers = getCustomTransformers(instance.program);
+    instance.transformers = getCustomTransformers(instance.program, loader);
   } else {
     const servicesHost = makeServicesHost(
       scriptRegex,
@@ -331,7 +331,8 @@ function successfulTypeScriptInstance(
     }
 
     instance.transformers = getCustomTransformers(
-      instance.languageService!.getProgram()
+      instance.languageService!.getProgram(),
+      loader
     );
   }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,6 @@
 export { ModuleResolutionHost, FormatDiagnosticsHost } from 'typescript';
 import * as typescript from 'typescript';
+import * as webpack from 'webpack';
 
 import { Chalk } from 'chalk';
 
@@ -203,7 +204,8 @@ export interface LoaderOptions {
   getCustomTransformers:
     | string
     | ((
-        program: typescript.Program
+        program: typescript.Program,
+        loader: webpack.loader.LoaderContext
       ) => typescript.CustomTransformers | undefined);
   experimentalWatchApi: boolean;
   allowTsInNodeModules: boolean;

--- a/test/comparison-tests/customTransformer/webpack.config.js
+++ b/test/comparison-tests/customTransformer/webpack.config.js
@@ -1,4 +1,5 @@
 var path = require('path')
+var assert = require('assert')
 
 var uppercaseStringLiteralTransformer = require('./uppercaseStringLiteralTransformer').default;
 
@@ -17,9 +18,12 @@ module.exports = {
                 test: /\.ts$/,
                 loader: 'ts-loader',
                 options: {
-                    getCustomTransformers: (program) => ({
-                        before: [uppercaseStringLiteralTransformer]
-                    })
+                    getCustomTransformers: (program, loaderContext) => {
+                        assert(loaderContext)
+                        return {
+                            before: [uppercaseStringLiteralTransformer]
+                        }
+                    }
                 }
             }
         ]


### PR DESCRIPTION
It is necessary to expose webpack loader context to custom transformer factory function. For example, when the transformer examine the AST and need to call `loaderContext.addDependency()`
