### PR TITLE
fix: watch-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v7.0.1
+* [fix: watch-run](https://github.com/TypeStrong/ts-loader/pull/1083) - thanks @zn4rk
+
 ## v7.0.0
 * [Project reference support enhancements](https://github.com/TypeStrong/ts-loader/pull/1076) - thanks @sheetalkamat!
 * Following the end of life of Node 8, `ts-loader` no longer supports Node 8 **BREAKING CHANGE**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ts"
   ],
   "engines": {
-    "node": ">=8.6"
+    "node": ">=10.0.0"
   },
   "author": "John Reilly <johnny_reilly@hotmail.com> (https://blog.johnnyreilly.com)",
   "contributors": [

--- a/src/watch-run.ts
+++ b/src/watch-run.ts
@@ -14,15 +14,15 @@ export function makeWatchRun(instance: TSInstance) {
   const startTime = 0;
 
   return (compiler: webpack.Compiler, callback: () => void) => {
-    const times = compiler.fileTimestamps;
     if (instance.loaderOptions.transpileOnly) {
       instance.reportTranspileErrors = true;
     } else {
+      const times = compiler.fileTimestamps;
+
       for (const [filePath, date] of times) {
-        if (
-          date > (lastTimes.get(filePath) || startTime) &&
-          filePath.match(constants.tsTsxJsJsxRegex) !== null
-        ) {
+        const lastTime = lastTimes.get(filePath) || startTime;
+
+        if (date <= lastTime) {
           continue;
         }
 

--- a/test/comparison-tests/importsWatch/expectedOutput-3.8/patch1/bundle.js
+++ b/test/comparison-tests/importsWatch/expectedOutput-3.8/patch1/bundle.js
@@ -94,19 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
-
-/***/ }),
-
-/***/ "./lib/index.ts":
-/*!**********************!*\
-  !*** ./lib/index.ts ***!
-  \**********************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-eval("\nexports.__esModule = true;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nvar foo;\nfoo.bar = 'foobar';\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/importsWatch/expectedOutput-3.8/patch1/output.txt
+++ b/test/comparison-tests/importsWatch/expectedOutput-3.8/patch1/output.txt
@@ -1,0 +1,9 @@
+    Asset      Size  Chunks             Chunk Names
+bundle.js  3.83 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[./app.ts] 70 bytes {main} [built] [1 error]
+
+ERROR in app.ts
+./app.ts
+[90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(4,1)[39m[22m
+[1m[31m      TS2322: Type '"foobar"' is not assignable to type 'boolean'.[39m[22m

--- a/test/comparison-tests/projectReferencesWatchRefWithTwoFilesAlreadyBuilt_Composite_WatchApi/expectedOutput-3.8/patch2/bundle.js
+++ b/test/comparison-tests/projectReferencesWatchRefWithTwoFilesAlreadyBuilt_Composite_WatchApi/expectedOutput-3.8/patch2/bundle.js
@@ -94,7 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nvar helper_1 = __webpack_require__(/*! ./lib/helper */ \"./lib/helper.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three, helper_1.helper.four); // consume new number\n\n\n//# sourceURL=webpack:///./app.ts?");
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ }),
 
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.helper = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/helper.ts?");
+eval("\nexports.__esModule = true;\nexports.helper = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4\n};\n\n\n//# sourceURL=webpack:///./lib/helper.ts?");
 
 /***/ }),
 
@@ -118,7 +118,7 @@ eval("\r\nexports.__esModule = true;\r\nexports.helper = {\r\n    one: 1,\r\n   
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nvar helper_1 = __webpack_require__(/*! ./helper */ \"./lib/helper.ts\");\r\nexports.lib = {\r\n    one: helper_1.helper.one,\r\n    two: helper_1.helper.two,\r\n    three: helper_1.helper.three,\r\n    four: 4\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nvar helper_1 = __webpack_require__(/*! ./helper */ \"./lib/helper.ts\");\nexports.lib = {\n    one: helper_1.helper.one,\n    two: helper_1.helper.two,\n    three: helper_1.helper.three,\n    four: 4\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatchRefWithTwoFilesAlreadyBuilt_Composite_WatchApi/expectedOutput-3.8/patch2/output.txt
+++ b/test/comparison-tests/projectReferencesWatchRefWithTwoFilesAlreadyBuilt_Composite_WatchApi/expectedOutput-3.8/patch2/output.txt
@@ -1,8 +1,7 @@
-                  Asset      Size  Chunks             Chunk Names
-              bundle.js  4.95 KiB    main  [emitted]  main
-            ../app.d.ts  11 bytes          [emitted]  
-../tsconfig.tsbuildinfo  52.2 KiB          [emitted]  
+      Asset      Size  Chunks             Chunk Names
+  bundle.js   4.8 KiB    main  [emitted]  main
+../app.d.ts  11 bytes          [emitted]  
 Entrypoint main = bundle.js
-[./app.ts] 215 bytes {main} [built]
-[./lib/helper.ts] 121 bytes {main}
-[./lib/index.ts] 211 bytes {main}
+[./app.ts] 131 bytes {main} [built]
+[./lib/helper.ts] 113 bytes {main}
+[./lib/index.ts] 202 bytes {main}

--- a/test/comparison-tests/projectReferencesWatchRefWithTwoFilesAlreadyBuilt_WatchApi/expectedOutput-3.8/patch2/bundle.js
+++ b/test/comparison-tests/projectReferencesWatchRefWithTwoFilesAlreadyBuilt_WatchApi/expectedOutput-3.8/patch2/bundle.js
@@ -94,7 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nvar helper_1 = __webpack_require__(/*! ./lib/helper */ \"./lib/helper.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three, helper_1.helper.four); // consume new number\n\n\n//# sourceURL=webpack:///./app.ts?");
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ }),
 
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.helper = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/helper.ts?");
+eval("\nexports.__esModule = true;\nexports.helper = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4\n};\n\n\n//# sourceURL=webpack:///./lib/helper.ts?");
 
 /***/ }),
 
@@ -118,7 +118,7 @@ eval("\r\nexports.__esModule = true;\r\nexports.helper = {\r\n    one: 1,\r\n   
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nvar helper_1 = __webpack_require__(/*! ./helper */ \"./lib/helper.ts\");\r\nexports.lib = {\r\n    one: helper_1.helper.one,\r\n    two: helper_1.helper.two,\r\n    three: helper_1.helper.three,\r\n    four: 4\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nvar helper_1 = __webpack_require__(/*! ./helper */ \"./lib/helper.ts\");\nexports.lib = {\n    one: helper_1.helper.one,\n    two: helper_1.helper.two,\n    three: helper_1.helper.three,\n    four: 4\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatchRefWithTwoFiles_Composite_WatchApi/expectedOutput-3.8/bundle.js
+++ b/test/comparison-tests/projectReferencesWatchRefWithTwoFiles_Composite_WatchApi/expectedOutput-3.8/bundle.js
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.helper = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/helper.ts?");
+eval("\nexports.__esModule = true;\nexports.helper = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///./lib/helper.ts?");
 
 /***/ }),
 
@@ -118,7 +118,7 @@ eval("\r\nexports.__esModule = true;\r\nexports.helper = {\r\n    one: 1,\r\n   
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nvar helper_1 = __webpack_require__(/*! ./helper */ \"./lib/helper.ts\");\r\nexports.lib = {\r\n    one: helper_1.helper.one,\r\n    two: helper_1.helper.two,\r\n    three: helper_1.helper.three\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nvar helper_1 = __webpack_require__(/*! ./helper */ \"./lib/helper.ts\");\nexports.lib = {\n    one: helper_1.helper.one,\n    two: helper_1.helper.two,\n    three: helper_1.helper.three\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatchRefWithTwoFiles_Composite_WatchApi/expectedOutput-3.8/output.txt
+++ b/test/comparison-tests/projectReferencesWatchRefWithTwoFiles_Composite_WatchApi/expectedOutput-3.8/output.txt
@@ -1,15 +1,15 @@
                       Asset       Size  Chunks             Chunk Names
-                  bundle.js    4.8 KiB    main  [emitted]  main
+                  bundle.js   4.77 KiB    main  [emitted]  main
                 ../app.d.ts   11 bytes          [emitted]  
     ../tsconfig.tsbuildinfo   51.8 KiB          [emitted]  
        ../lib/helper.js.map  189 bytes          [emitted]  
-           ../lib/helper.js  141 bytes          [emitted]  
-         ../lib/helper.d.ts   92 bytes          [emitted]  
+           ../lib/helper.js  134 bytes          [emitted]  
+         ../lib/helper.d.ts   87 bytes          [emitted]  
         ../lib/index.js.map  231 bytes          [emitted]  
-            ../lib/index.js  230 bytes          [emitted]  
-          ../lib/index.d.ts   89 bytes          [emitted]  
+            ../lib/index.js  222 bytes          [emitted]  
+          ../lib/index.d.ts   84 bytes          [emitted]  
 ../lib/tsconfig.tsbuildinfo   67.8 KiB          [emitted]  
 Entrypoint main = bundle.js
 [./app.ts] 131 bytes {main} [built]
-[./lib/helper.ts] 107 bytes {main} [built]
-[./lib/index.ts] 197 bytes {main} [built]
+[./lib/helper.ts] 100 bytes {main} [built]
+[./lib/index.ts] 189 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesWatchRefWithTwoFiles_Composite_WatchApi/expectedOutput-3.8/patch0/bundle.js
+++ b/test/comparison-tests/projectReferencesWatchRefWithTwoFiles_Composite_WatchApi/expectedOutput-3.8/patch0/bundle.js
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.helper = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/helper.ts?");
+eval("\nexports.__esModule = true;\nexports.helper = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4\n};\n\n\n//# sourceURL=webpack:///./lib/helper.ts?");
 
 /***/ }),
 
@@ -118,7 +118,7 @@ eval("\r\nexports.__esModule = true;\r\nexports.helper = {\r\n    one: 1,\r\n   
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nvar helper_1 = __webpack_require__(/*! ./helper */ \"./lib/helper.ts\");\r\nexports.lib = {\r\n    one: helper_1.helper.one,\r\n    two: helper_1.helper.two,\r\n    three: helper_1.helper.three\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nvar helper_1 = __webpack_require__(/*! ./helper */ \"./lib/helper.ts\");\nexports.lib = {\n    one: helper_1.helper.one,\n    two: helper_1.helper.two,\n    three: helper_1.helper.three\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatchRefWithTwoFiles_Composite_WatchApi/expectedOutput-3.8/patch0/output.txt
+++ b/test/comparison-tests/projectReferencesWatchRefWithTwoFiles_Composite_WatchApi/expectedOutput-3.8/patch0/output.txt
@@ -1,14 +1,14 @@
                       Asset       Size  Chunks             Chunk Names
-                  bundle.js   4.82 KiB    main  [emitted]  main
+                  bundle.js   4.79 KiB    main  [emitted]  main
                 ../app.d.ts   11 bytes          [emitted]  
        ../lib/helper.js.map  209 bytes          [emitted]  
-           ../lib/helper.js  155 bytes          [emitted]  
-         ../lib/helper.d.ts  111 bytes          [emitted]  
+           ../lib/helper.js  147 bytes          [emitted]  
+         ../lib/helper.d.ts  105 bytes          [emitted]  
         ../lib/index.js.map  231 bytes          [emitted]  
-            ../lib/index.js  230 bytes          [emitted]  
-          ../lib/index.d.ts   89 bytes          [emitted]  
+            ../lib/index.js  222 bytes          [emitted]  
+          ../lib/index.d.ts   84 bytes          [emitted]  
 ../lib/tsconfig.tsbuildinfo   67.8 KiB          [emitted]  
 Entrypoint main = bundle.js
 [./app.ts] 131 bytes {main} [built]
-[./lib/helper.ts] 121 bytes {main} [built]
-[./lib/index.ts] 197 bytes {main} [built]
+[./lib/helper.ts] 113 bytes {main} [built]
+[./lib/index.ts] 189 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesWatchRefWithTwoFiles_Composite_WatchApi/expectedOutput-3.8/patch1/bundle.js
+++ b/test/comparison-tests/projectReferencesWatchRefWithTwoFiles_Composite_WatchApi/expectedOutput-3.8/patch1/bundle.js
@@ -94,7 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nvar helper_1 = __webpack_require__(/*! ./lib/helper */ \"./lib/helper.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three, helper_1.helper.four); // consume new number\n\n\n//# sourceURL=webpack:///./app.ts?");
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ }),
 
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.helper = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/helper.ts?");
+eval("\nexports.__esModule = true;\nexports.helper = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4\n};\n\n\n//# sourceURL=webpack:///./lib/helper.ts?");
 
 /***/ }),
 
@@ -118,7 +118,7 @@ eval("\r\nexports.__esModule = true;\r\nexports.helper = {\r\n    one: 1,\r\n   
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nvar helper_1 = __webpack_require__(/*! ./helper */ \"./lib/helper.ts\");\r\nexports.lib = {\r\n    one: helper_1.helper.one,\r\n    two: helper_1.helper.two,\r\n    three: helper_1.helper.three\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nvar helper_1 = __webpack_require__(/*! ./helper */ \"./lib/helper.ts\");\nexports.lib = {\n    one: helper_1.helper.one,\n    two: helper_1.helper.two,\n    three: helper_1.helper.three\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatchRefWithTwoFiles_Composite_WatchApi/expectedOutput-3.8/patch1/output.txt
+++ b/test/comparison-tests/projectReferencesWatchRefWithTwoFiles_Composite_WatchApi/expectedOutput-3.8/patch1/output.txt
@@ -1,8 +1,7 @@
-                  Asset      Size  Chunks             Chunk Names
-              bundle.js  4.94 KiB    main  [emitted]  main
-            ../app.d.ts  11 bytes          [emitted]  
-../tsconfig.tsbuildinfo  52.2 KiB          [emitted]  
+      Asset      Size  Chunks             Chunk Names
+  bundle.js  4.79 KiB    main  [emitted]  main
+../app.d.ts  11 bytes          [emitted]  
 Entrypoint main = bundle.js
-[./app.ts] 215 bytes {main} [built]
-[./lib/helper.ts] 121 bytes {main}
-[./lib/index.ts] 197 bytes {main}
+[./app.ts] 131 bytes {main} [built]
+[./lib/helper.ts] 113 bytes {main}
+[./lib/index.ts] 189 bytes {main}

--- a/test/comparison-tests/projectReferencesWatchRefWithTwoFiles_WatchApi/expectedOutput-3.8/patch1/bundle.js
+++ b/test/comparison-tests/projectReferencesWatchRefWithTwoFiles_WatchApi/expectedOutput-3.8/patch1/bundle.js
@@ -94,7 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nvar helper_1 = __webpack_require__(/*! ./lib/helper */ \"./lib/helper.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three, helper_1.helper.four); // consume new number\n\n\n//# sourceURL=webpack:///./app.ts?");
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ }),
 
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.helper = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/helper.ts?");
+eval("\nexports.__esModule = true;\nexports.helper = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4\n};\n\n\n//# sourceURL=webpack:///./lib/helper.ts?");
 
 /***/ }),
 
@@ -118,7 +118,7 @@ eval("\r\nexports.__esModule = true;\r\nexports.helper = {\r\n    one: 1,\r\n   
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nvar helper_1 = __webpack_require__(/*! ./helper */ \"./lib/helper.ts\");\r\nexports.lib = {\r\n    one: helper_1.helper.one,\r\n    two: helper_1.helper.two,\r\n    three: helper_1.helper.three\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nvar helper_1 = __webpack_require__(/*! ./helper */ \"./lib/helper.ts\");\nexports.lib = {\n    one: helper_1.helper.one,\n    two: helper_1.helper.two,\n    three: helper_1.helper.three\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/output.txt
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/output.txt
@@ -1,11 +1,11 @@
                       Asset       Size  Chunks             Chunk Names
-                  bundle.js   4.29 KiB    main  [emitted]  main
+                  bundle.js   4.28 KiB    main  [emitted]  main
                 ../app.d.ts   11 bytes          [emitted]  
     ../tsconfig.tsbuildinfo   51.8 KiB          [emitted]  
         ../lib/index.js.map  187 bytes          [emitted]  
-            ../lib/index.js  137 bytes          [emitted]  
-          ../lib/index.d.ts   89 bytes          [emitted]  
+            ../lib/index.js  130 bytes          [emitted]  
+          ../lib/index.d.ts   84 bytes          [emitted]  
 ../lib/tsconfig.tsbuildinfo   67.4 KiB          [emitted]  
 Entrypoint main = bundle.js
 [./app.ts] 131 bytes {main} [built]
-[./lib/index.ts] 104 bytes {main} [built]
+[./lib/index.ts] 97 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch0/bundle.js
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch0/bundle.js
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.lib = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4 // Add new number\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4 // Add new number\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch0/output.txt
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch0/output.txt
@@ -1,10 +1,10 @@
                       Asset       Size  Chunks             Chunk Names
-                  bundle.js   4.33 KiB    main  [emitted]  main
+                  bundle.js   4.31 KiB    main  [emitted]  main
                 ../app.d.ts   11 bytes          [emitted]  
         ../lib/index.js.map  220 bytes          [emitted]  
-            ../lib/index.js  169 bytes          [emitted]  
-          ../lib/index.d.ts  108 bytes          [emitted]  
+            ../lib/index.js  161 bytes          [emitted]  
+          ../lib/index.d.ts  102 bytes          [emitted]  
 ../lib/tsconfig.tsbuildinfo   67.4 KiB          [emitted]  
 Entrypoint main = bundle.js
 [./app.ts] 131 bytes {main} [built]
-[./lib/index.ts] 136 bytes {main} [built]
+[./lib/index.ts] 128 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch1/bundle.js
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch1/bundle.js
@@ -94,7 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three, lib_1.lib.four); // consume new number\n\n\n//# sourceURL=webpack:///./app.ts?");
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ }),
 
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.lib = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4 // Add new number\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4 // Add new number\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch1/output.txt
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch1/output.txt
@@ -1,7 +1,6 @@
-                  Asset      Size  Chunks             Chunk Names
-              bundle.js  4.36 KiB    main  [emitted]  main
-            ../app.d.ts  11 bytes          [emitted]  
-../tsconfig.tsbuildinfo  51.8 KiB          [emitted]  
+      Asset      Size  Chunks             Chunk Names
+  bundle.js  4.31 KiB    main  [emitted]  main
+../app.d.ts  11 bytes          [emitted]  
 Entrypoint main = bundle.js
-[./app.ts] 169 bytes {main} [built]
-[./lib/index.ts] 136 bytes {main}
+[./app.ts] 131 bytes {main} [built]
+[./lib/index.ts] 128 bytes {main}

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch2/bundle.js
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch2/bundle.js
@@ -94,7 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three, lib_1.lib.four); // consume new number\n\n\n//# sourceURL=webpack:///./app.ts?");
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ }),
 
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.lib = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4 // Add new number\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4 // Add new number\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch2/output.txt
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch2/output.txt
@@ -1,16 +1,16 @@
       Asset      Size  Chunks             Chunk Names
-  bundle.js  4.36 KiB    main  [emitted]  main
+  bundle.js  4.31 KiB    main  [emitted]  main
 ../app.d.ts  11 bytes          [emitted]  
 Entrypoint main = bundle.js
-[./app.ts] 169 bytes {main} [built]
-[./lib/index.ts] 136 bytes {main} [built] [2 errors]
+[./app.ts] 131 bytes {main} [built]
+[./lib/index.ts] 128 bytes {main} [built] [2 errors]
 
-ERROR in lib\index.ts
+ERROR in lib/index.ts
 ./lib/index.ts
-[90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib\index.ts(6,3)[39m[22m
+[90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib/index.ts(6,3)[39m[22m
 [1m[31m      TS1136: Property assignment expected.[39m[22m
 
-ERROR in lib\index.ts
+ERROR in lib/index.ts
 ./lib/index.ts
-[90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib\index.ts(7,1)[39m[22m
+[90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib/index.ts(7,1)[39m[22m
 [1m[31m      TS1128: Declaration or statement expected.[39m[22m

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch3/bundle.js
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch3/bundle.js
@@ -94,7 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three, lib_1.lib.four); // consume new number\n\n\n//# sourceURL=webpack:///./app.ts?");
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ }),
 
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.lib = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4,\r\n    five: 5\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4,\n    five: 5\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch3/output.txt
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch3/output.txt
@@ -1,10 +1,10 @@
                       Asset       Size  Chunks             Chunk Names
-                  bundle.js   4.36 KiB    main  [emitted]  main
+                  bundle.js   4.31 KiB    main  [emitted]  main
                 ../app.d.ts   11 bytes          [emitted]  
         ../lib/index.js.map  227 bytes          [emitted]  
-            ../lib/index.js  165 bytes          [emitted]  
-          ../lib/index.d.ts  127 bytes          [emitted]  
+            ../lib/index.js  156 bytes          [emitted]  
+          ../lib/index.d.ts  120 bytes          [emitted]  
 ../lib/tsconfig.tsbuildinfo   67.4 KiB          [emitted]  
 Entrypoint main = bundle.js
-[./app.ts] 169 bytes {main} [built]
-[./lib/index.ts] 132 bytes {main} [built]
+[./app.ts] 131 bytes {main} [built]
+[./lib/index.ts] 123 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch4/bundle.js
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch4/bundle.js
@@ -94,7 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three, lib_1.lib.four, lib_1.lib.ffive); // consume new number\n\n\n//# sourceURL=webpack:///./app.ts?");
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ }),
 
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.lib = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4,\r\n    five: 5\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4,\n    five: 5\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch4/output.txt
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch4/output.txt
@@ -1,12 +1,6 @@
-                  Asset      Size  Chunks             Chunk Names
-              bundle.js  4.38 KiB    main  [emitted]  main
-            ../app.d.ts  11 bytes          [emitted]  
-../tsconfig.tsbuildinfo  51.8 KiB          [emitted]  
+      Asset      Size  Chunks             Chunk Names
+  bundle.js  4.31 KiB    main  [emitted]  main
+../app.d.ts  11 bytes          [emitted]  
 Entrypoint main = bundle.js
-[./app.ts] 186 bytes {main} [built] [1 error]
-[./lib/index.ts] 132 bytes {main}
-
-ERROR in app.ts
-./app.ts
-[90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(3,56)[39m[22m
-[1m[31m      TS2551: Property 'ffive' does not exist on type '{ one: number; two: number; three: number; four: number; five: number; }'. Did you mean 'five'?[39m[22m
+[./app.ts] 131 bytes {main} [built]
+[./lib/index.ts] 123 bytes {main}

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch5/bundle.js
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch5/bundle.js
@@ -94,7 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three, lib_1.lib.four, lib_1.lib.five); // consume new number\n\n\n//# sourceURL=webpack:///./app.ts?");
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ }),
 
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.lib = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4,\r\n    five: 5\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4,\n    five: 5\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch5/output.txt
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch5/output.txt
@@ -1,7 +1,6 @@
-                  Asset      Size  Chunks             Chunk Names
-              bundle.js  4.38 KiB    main  [emitted]  main
-            ../app.d.ts  11 bytes          [emitted]  
-../tsconfig.tsbuildinfo  51.8 KiB          [emitted]  
+      Asset      Size  Chunks             Chunk Names
+  bundle.js  4.31 KiB    main  [emitted]  main
+../app.d.ts  11 bytes          [emitted]  
 Entrypoint main = bundle.js
-[./app.ts] 185 bytes {main} [built]
-[./lib/index.ts] 132 bytes {main}
+[./app.ts] 131 bytes {main} [built]
+[./lib/index.ts] 123 bytes {main}

--- a/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-3.8/patch1/bundle.js
+++ b/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-3.8/patch1/bundle.js
@@ -94,7 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three, lib_1.lib.four); // consume new number\n\n\n//# sourceURL=webpack:///./app.ts?");
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ }),
 
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.lib = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4 // Add new number\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4 // Add new number\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-3.8/patch2/bundle.js
+++ b/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-3.8/patch2/bundle.js
@@ -94,7 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three, lib_1.lib.four); // consume new number\n\n\n//# sourceURL=webpack:///./app.ts?");
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ }),
 
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.lib = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4 // Add new number\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4 // Add new number\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-3.8/patch3/bundle.js
+++ b/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-3.8/patch3/bundle.js
@@ -94,7 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three, lib_1.lib.four); // consume new number\n\n\n//# sourceURL=webpack:///./app.ts?");
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ }),
 
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.lib = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4,\r\n    five: 5\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4,\n    five: 5\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-3.8/patch4/bundle.js
+++ b/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-3.8/patch4/bundle.js
@@ -94,7 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three, lib_1.lib.four, lib_1.lib.ffive); // consume new number\n\n\n//# sourceURL=webpack:///./app.ts?");
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ }),
 
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.lib = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4,\r\n    five: 5\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4,\n    five: 5\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 

--- a/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-3.8/patch4/output.txt
+++ b/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-3.8/patch4/output.txt
@@ -1,10 +1,5 @@
     Asset      Size  Chunks             Chunk Names
-bundle.js  4.38 KiB    main  [emitted]  main
+bundle.js  4.31 KiB    main  [emitted]  main
 Entrypoint main = bundle.js
-[./app.ts] 186 bytes {main} [built] [1 error]
-[./lib/index.ts] 132 bytes {main}
-
-ERROR in app.ts
-./app.ts
-[90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(3,56)[39m[22m
-[1m[31m      TS2551: Property 'ffive' does not exist on type '{ one: number; two: number; three: number; four: number; five: number; }'. Did you mean 'five'?[39m[22m
+[./app.ts] 131 bytes {main} [built]
+[./lib/index.ts] 123 bytes {main}

--- a/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-3.8/patch5/bundle.js
+++ b/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-3.8/patch5/bundle.js
@@ -94,7 +94,7 @@
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three, lib_1.lib.four, lib_1.lib.five); // consume new number\n\n\n//# sourceURL=webpack:///./app.ts?");
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */ \"./lib/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\n\n\n//# sourceURL=webpack:///./app.ts?");
 
 /***/ }),
 
@@ -106,7 +106,7 @@ eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ./lib */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\r\nexports.__esModule = true;\r\nexports.lib = {\r\n    one: 1,\r\n    two: 2,\r\n    three: 3,\r\n    four: 4,\r\n    five: 5\r\n};\r\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
+eval("\nexports.__esModule = true;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3,\n    four: 4,\n    five: 5\n};\n\n\n//# sourceURL=webpack:///./lib/index.ts?");
 
 /***/ })
 


### PR DESCRIPTION
Closes #1082 

I need a bit of help verifying that these tests are correct. I tried to understand what's happening with _WatchApi, but couldn't wrap my head around it. 

It looks scary to change `/projectReferencesWatch_Composite_WatchApi/expectedOutput-3.8/patch4/output.txt` to not emit an error, but `projectReferencesWatch` still has the corresponding error.