### PR TITLE
Make content hash consistent across machines

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -528,7 +528,7 @@ function getEmit(
 
   loaderContext._module.buildMeta.tsLoaderDefinitionFileVersions = dependencies.map(
     defFilePath =>
-      defFilePath +
+      path.relative(loaderContext.rootContext,defFilePath) +
       '@' +
       (
         instance.files.get(defFilePath) ||


### PR DESCRIPTION
Credit to @elyalvarado.
This PR is simply a rebased #1085 
Open this PR because the original PR seems to be inactive.
Here's a copy of the original description.

The metadata used for calculating the content/chunk hash by Webpack was including the absolute paths for all the definition files and additional dependencies, which caused the calculated hash to be different depending on the absolute path of the root context. This caused the hash to change between different machines even if there were no changes in the code, which in turn causes issues in certain deployment environments where the build is executed in different server, as is the case in the default Rails deployments in AWS OpsWorks.

This is similar to the issue described in #1048

This PR changes the paths added to the build metadata to be relative to the root context, which makes the content/chunk hash calculation consistent across builds in different machines.
