### PR TITLE
Change README and examples from obsolete checkSyntacticErrors to syntactic diagnostic option

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,10 +321,17 @@ module.exports = {
 
 If you're using [HappyPack](https://github.com/amireh/happypack) or [thread-loader](https://github.com/webpack-contrib/thread-loader) to parallise your builds then you'll need to set this to `true`. This implicitly sets `*transpileOnly*` to `true` and **WARNING!** stops registering **_all_** errors to webpack.
 
-It's advisable to use this with the [fork-ts-checker-webpack-plugin](https://github.com/Realytics/fork-ts-checker-webpack-plugin) to get full type checking again. To see what this looks like in practice then either take a look at [our simple thread-loader example](examples/thread-loader). **_IMPORTANT_**: If you are using fork-ts-checker-webpack-plugin alongside HappyPack or thread-loader then ensure you set the `checkSyntacticErrors` option like so:
+It's advisable to use this with the [fork-ts-checker-webpack-plugin](https://github.com/Realytics/fork-ts-checker-webpack-plugin) to get full type checking again. To see what this looks like in practice then either take a look at [our simple thread-loader example](examples/thread-loader). **_IMPORTANT_**: If you are using fork-ts-checker-webpack-plugin alongside HappyPack or thread-loader then ensure you set the `syntactic` diagnostic option like so:
 
 ```javascript
-        new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true })
+        new ForkTsCheckerWebpackPlugin({
+          typescript: {
+            diagnosticOptions: {
+              semantic: true,
+              syntactic: true,
+            },
+          },
+        })
 ```
 
 This will ensure that the plugin checks for both syntactic errors (eg `const array = [{} {}];`) and semantic errors (eg `const x: number = '1';`). By default the plugin only checks for semantic errors (as when used with `ts-loader` in `transpileOnly` mode, `ts-loader` will still report syntactic errors).

--- a/examples/thread-loader/package.json
+++ b/examples/thread-loader/package.json
@@ -6,12 +6,12 @@
     "start": "webpack --watch --mode development"
   },
   "devDependencies": {
-    "cache-loader": "^1.2.0",
-    "fork-ts-checker-webpack-plugin": "^0.4.1",
-    "thread-loader": "^1.1.4",
-    "ts-loader": "^4.0.0",
-    "typescript": "^2.7.2",
-    "webpack": "^4.0.0",
-    "webpack-cli": "^2.0.9"
+    "cache-loader": "^4.1.0",
+    "fork-ts-checker-webpack-plugin": "^5.0.7",
+    "thread-loader": "^2.1.3",
+    "ts-loader": "^8.0.0",
+    "typescript": "^3.9.6",
+    "webpack": "^4.43.0",
+    "webpack-cli": "^3.3.12"
   }
 }

--- a/examples/thread-loader/webpack.config.js
+++ b/examples/thread-loader/webpack.config.js
@@ -33,6 +33,13 @@ module.exports = {
         extensions: ['.ts', '.tsx', 'js']
     },
     plugins: [
-        new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true })
+        new ForkTsCheckerWebpackPlugin({
+          typescript: {
+            diagnosticOptions: {
+              semantic: true,
+              syntactic: true
+            }
+          }
+        })
     ]
 };


### PR DESCRIPTION
`checkSyntacticErrors` option is not available anymore. We are supposed to use diagnosticOptions now (see https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/issues/477)

This PR updates README and thread-loader example accordingly.



