### PR TITLE
devcontainer for ts-loader

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,40 @@
+#-------------------------------------------------------------------------------------------------------------
+# Based on:
+# https://github.com/microsoft/vscode-dev-containers/tree/v0.122.1/containers/typescript-node-14/.devcontainer/Dockerfile
+#-------------------------------------------------------------------------------------------------------------
+
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:14
+
+# The javascript-node image includes a non-root node user with sudo access. Use 
+# the "remoteUser" property in devcontainer.json to use it. On Linux, the container 
+# user's GID/UIDs will be updated to match your local UID/GID when using the image
+# or dockerFile property. Update USER_UID/USER_GID below if you are using the
+# dockerComposeFile property or want the image itself to start with different ID
+# values. See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=node
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Alter node user as needed. eslint is installed by javascript image
+RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
+        groupmod --gid $USER_GID $USERNAME \
+        && usermod --uid $USER_UID --gid $USER_GID $USERNAME \
+        && chmod -R $USER_UID:$USER_GID /home/$USERNAME \
+        && chmod -R $USER_UID:root /usr/local/share/nvm /usr/local/share/npm-global; \
+    fi
+
+# Set the Chrome repo.
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
+
+# Install Chrome.
+RUN apt-get update && apt-get -y install google-chrome-stable \
+    && rm -rf /var/lib/apt/lists/*
+
+
+# ** [Optional] Uncomment this section to install additional packages. **
+#
+# RUN apt-get update \
+#     && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.122.1/containers/typescript-node-14
+{
+	"name": "ts-loader devcontainer",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/zsh"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [/* for debugging execution tests */ 9876],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "yarn install",
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "node"
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.devcontainer
 .git
 .github
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ npm-debug.log
 .pnp.js
 !.eslintrc.js
 .vs/**
+.pnpm-store

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+.devcontainer
 .vscode
 .test
 examples

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: node_js
 node_js:
   - "10"
   - "12"
+  - "14"
 sudo: required
 install:
   - yarn install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:14
 
 # See https://crbug.com/795759
 RUN apt-get update && apt-get install -yq libgconf-2-4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2017
 environment:
   FORCE_COLOR: 1
-  nodejs_version: "10"
+  nodejs_version: "14"
   matrix:
   - TYPESCRIPT: typescript@3.9.3
   - TYPESCRIPT: typescript@next

--- a/test/execution-tests/pnpm/pnpm-lock.yaml
+++ b/test/execution-tests/pnpm/pnpm-lock.yaml
@@ -1,0 +1,370 @@
+dependencies:
+  '@types/react': registry.npmjs.org/@types/react/16.3.12
+  '@types/react-dom': registry.npmjs.org/@types/react-dom/16.0.5
+  office-ui-fabric-react: registry.npmjs.org/office-ui-fabric-react/5.88.0_e988b2cc8bc9683402b3bc67ea579787
+  react: registry.npmjs.org/react/16.3.2
+  react-dom: registry.npmjs.org/react-dom/16.3.2_react@16.3.2
+lockfileVersion: 5.1
+packages:
+  registry.npmjs.org/@microsoft/load-themed-styles/1.10.65:
+    dev: false
+    name: '@microsoft/load-themed-styles'
+    resolution:
+      integrity: sha512-4sLbMM9aywtSMRHebh912/6n4/lC/go6QlTbbQfIBBtfy0oQJdDOW1KtfZfSGPggoPiNEzA7xnVsFCFyMnZyEg==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.65.tgz'
+    version: 1.10.65
+  registry.npmjs.org/@types/node/14.0.22:
+    dev: false
+    name: '@types/node'
+    resolution:
+      integrity: sha512-emeGcJvdiZ4Z3ohbmw93E/64jRzUHAItSHt8nF7M4TGgQTiWqFVGB8KNpLGFmUHmHLvjvBgFwVlqNcq+VuGv9g==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/@types/node/-/node-14.0.22.tgz'
+    version: 14.0.22
+  registry.npmjs.org/@types/react-dom/16.0.5:
+    dependencies:
+      '@types/node': registry.npmjs.org/@types/node/14.0.22
+      '@types/react': registry.npmjs.org/@types/react/16.3.12
+    dev: false
+    name: '@types/react-dom'
+    resolution:
+      integrity: sha512-ony2hEYlGXCLWNAWWgbsHR7qVvDbeMRFc5b43+7dhj3n+zXzxz81HV9Yjpc3JD8vLCiwYoSLqFCI6bD0+0zG2Q==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.5.tgz'
+    version: 16.0.5
+  registry.npmjs.org/@types/react/16.3.12:
+    dependencies:
+      csstype: registry.npmjs.org/csstype/2.6.11
+    dev: false
+    name: '@types/react'
+    resolution:
+      integrity: sha512-FfBhLC3QeXXEtjoGGLixS7cB305vzBOM1dZKtbUuXeTfjY0quzRRMxpqylC4QyUaLqdhNLdER0ZdHUGAVlGSCA==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/@types/react/-/react-16.3.12.tgz'
+    version: 16.3.12
+  registry.npmjs.org/@uifabric/icons/5.8.0_e988b2cc8bc9683402b3bc67ea579787:
+    dependencies:
+      '@uifabric/styling': registry.npmjs.org/@uifabric/styling/5.37.0_e988b2cc8bc9683402b3bc67ea579787
+      tslib: registry.npmjs.org/tslib/1.13.0
+    dev: false
+    id: registry.npmjs.org/@uifabric/icons/5.8.0
+    name: '@uifabric/icons'
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: '*'
+      react-dom: '*'
+    resolution:
+      integrity: sha512-EUhKxYlIPJshg4fQvCNTYSk0p7RhzEWeEAJBV4sao1SKmN0/pZBnkLbDqWjU5VUfdwZZYiIdaLRpM+pyzhniZw==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/@uifabric/icons/-/icons-5.8.0.tgz'
+    version: 5.8.0
+  registry.npmjs.org/@uifabric/merge-styles/5.17.1:
+    dependencies:
+      tslib: registry.npmjs.org/tslib/1.13.0
+    dev: false
+    name: '@uifabric/merge-styles'
+    resolution:
+      integrity: sha512-4/EtO6Ns7kNtKxC+6InShwVQeNQEDT5H8Ex7m/i4OrT9i7csje4YwBQPkkpm31qJwEZEyD7bbAwyLezI63sLhg==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-5.17.1.tgz'
+    version: 5.17.1
+  registry.npmjs.org/@uifabric/styling/5.37.0_e988b2cc8bc9683402b3bc67ea579787:
+    dependencies:
+      '@microsoft/load-themed-styles': registry.npmjs.org/@microsoft/load-themed-styles/1.10.65
+      '@uifabric/merge-styles': registry.npmjs.org/@uifabric/merge-styles/5.17.1
+      '@uifabric/utilities': registry.npmjs.org/@uifabric/utilities/5.34.3_e988b2cc8bc9683402b3bc67ea579787
+      tslib: registry.npmjs.org/tslib/1.13.0
+    dev: false
+    id: registry.npmjs.org/@uifabric/styling/5.37.0
+    name: '@uifabric/styling'
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: '*'
+      react-dom: '*'
+    resolution:
+      integrity: sha512-3hC0itW/hWSD5J4uANzUKk8XVGWUNkU+VLjEjWsQ6i5lvwFGaanR6Qy0bTkZdFGqFWMXe91CkBHV7HnvEx7tCA==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/@uifabric/styling/-/styling-5.37.0.tgz'
+    version: 5.37.0
+  registry.npmjs.org/@uifabric/utilities/5.34.3_e988b2cc8bc9683402b3bc67ea579787:
+    dependencies:
+      '@types/react': registry.npmjs.org/@types/react/16.3.12
+      '@types/react-dom': registry.npmjs.org/@types/react-dom/16.0.5
+      '@uifabric/merge-styles': registry.npmjs.org/@uifabric/merge-styles/5.17.1
+      prop-types: registry.npmjs.org/prop-types/15.7.2
+      react: registry.npmjs.org/react/16.3.2
+      react-dom: registry.npmjs.org/react-dom/16.3.2_react@16.3.2
+      tslib: registry.npmjs.org/tslib/1.13.0
+    dev: false
+    id: registry.npmjs.org/@uifabric/utilities/5.34.3
+    name: '@uifabric/utilities'
+    peerDependencies:
+      '@types/react': ^0.14.x || ^15.x || ^16.x
+      '@types/react-dom': ^0.14.x || ^15.x || ^16.x
+      react: ^0.14.9 || ^15.0.1-0 || ^16.0.0-0
+      react-dom: ^0.14.9 || ^15.0.1-0 || ^16.0.0-0
+    resolution:
+      integrity: sha512-6dERFkNNCUrPUuNG1nxlDDvt7DN5hxb41zp9AmKhK5cXZTYCblmlLBvb/qyielCnicfoagoA+lqH9NgnSE8u/A==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/@uifabric/utilities/-/utilities-5.34.3.tgz'
+    version: 5.34.3
+  registry.npmjs.org/asap/2.0.6:
+    dev: false
+    name: asap
+    resolution:
+      integrity: sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/asap/-/asap-2.0.6.tgz'
+    version: 2.0.6
+  registry.npmjs.org/core-js/1.2.7:
+    deprecated: 'core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.'
+    dev: false
+    name: core-js
+    resolution:
+      integrity: sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz'
+    version: 1.2.7
+  registry.npmjs.org/csstype/2.6.11:
+    dev: false
+    name: csstype
+    resolution:
+      integrity: sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/csstype/-/csstype-2.6.11.tgz'
+    version: 2.6.11
+  registry.npmjs.org/encoding/0.1.13:
+    dependencies:
+      iconv-lite: registry.npmjs.org/iconv-lite/0.6.2
+    dev: false
+    name: encoding
+    resolution:
+      integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz'
+    version: 0.1.13
+  registry.npmjs.org/fbjs/0.8.17:
+    dependencies:
+      core-js: registry.npmjs.org/core-js/1.2.7
+      isomorphic-fetch: registry.npmjs.org/isomorphic-fetch/2.2.1
+      loose-envify: registry.npmjs.org/loose-envify/1.4.0
+      object-assign: registry.npmjs.org/object-assign/4.1.1
+      promise: registry.npmjs.org/promise/7.3.1
+      setimmediate: registry.npmjs.org/setimmediate/1.0.5
+      ua-parser-js: registry.npmjs.org/ua-parser-js/0.7.21
+    dev: false
+    name: fbjs
+    resolution:
+      integrity: sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz'
+    version: 0.8.17
+  registry.npmjs.org/iconv-lite/0.6.2:
+    dependencies:
+      safer-buffer: registry.npmjs.org/safer-buffer/2.1.2
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    name: iconv-lite
+    resolution:
+      integrity: sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz'
+    version: 0.6.2
+  registry.npmjs.org/is-stream/1.1.0:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    name: is-stream
+    resolution:
+      integrity: sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz'
+    version: 1.1.0
+  registry.npmjs.org/isomorphic-fetch/2.2.1:
+    dependencies:
+      node-fetch: registry.npmjs.org/node-fetch/1.7.3
+      whatwg-fetch: registry.npmjs.org/whatwg-fetch/3.2.0
+    dev: false
+    name: isomorphic-fetch
+    resolution:
+      integrity: sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz'
+    version: 2.2.1
+  registry.npmjs.org/js-tokens/4.0.0:
+    dev: false
+    name: js-tokens
+    resolution:
+      integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz'
+    version: 4.0.0
+  registry.npmjs.org/loose-envify/1.4.0:
+    dependencies:
+      js-tokens: registry.npmjs.org/js-tokens/4.0.0
+    dev: false
+    hasBin: true
+    name: loose-envify
+    resolution:
+      integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz'
+    version: 1.4.0
+  registry.npmjs.org/node-fetch/1.7.3:
+    dependencies:
+      encoding: registry.npmjs.org/encoding/0.1.13
+      is-stream: registry.npmjs.org/is-stream/1.1.0
+    dev: false
+    name: node-fetch
+    resolution:
+      integrity: sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz'
+    version: 1.7.3
+  registry.npmjs.org/object-assign/4.1.1:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    name: object-assign
+    resolution:
+      integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz'
+    version: 4.1.1
+  registry.npmjs.org/office-ui-fabric-react/5.88.0_e988b2cc8bc9683402b3bc67ea579787:
+    dependencies:
+      '@microsoft/load-themed-styles': registry.npmjs.org/@microsoft/load-themed-styles/1.10.65
+      '@uifabric/icons': registry.npmjs.org/@uifabric/icons/5.8.0_e988b2cc8bc9683402b3bc67ea579787
+      '@uifabric/merge-styles': registry.npmjs.org/@uifabric/merge-styles/5.17.1
+      '@uifabric/styling': registry.npmjs.org/@uifabric/styling/5.37.0_e988b2cc8bc9683402b3bc67ea579787
+      '@uifabric/utilities': registry.npmjs.org/@uifabric/utilities/5.34.3_e988b2cc8bc9683402b3bc67ea579787
+      prop-types: registry.npmjs.org/prop-types/15.7.2
+      react: registry.npmjs.org/react/16.3.2
+      react-dom: registry.npmjs.org/react-dom/16.3.2_react@16.3.2
+      tslib: registry.npmjs.org/tslib/1.13.0
+    dev: false
+    id: registry.npmjs.org/office-ui-fabric-react/5.88.0
+    name: office-ui-fabric-react
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^0.14.9 || ^15.0.1-0 || ^16.0.0-0
+      react-dom: ^0.14.9 || ^15.0.1-0 || ^16.0.0-0
+    resolution:
+      integrity: sha512-Rz6q7wlIYwVurNqDusWX9YbvXjDsIS2qbRsam1Dg6iuNTefrZHFGrYV2c7T3NOBMEAA7Nc9muThqogHOF6lxQw==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-5.88.0.tgz'
+    version: 5.88.0
+  registry.npmjs.org/promise/7.3.1:
+    dependencies:
+      asap: registry.npmjs.org/asap/2.0.6
+    dev: false
+    name: promise
+    resolution:
+      integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/promise/-/promise-7.3.1.tgz'
+    version: 7.3.1
+  registry.npmjs.org/prop-types/15.7.2:
+    dependencies:
+      loose-envify: registry.npmjs.org/loose-envify/1.4.0
+      object-assign: registry.npmjs.org/object-assign/4.1.1
+      react-is: registry.npmjs.org/react-is/16.13.1
+    dev: false
+    name: prop-types
+    resolution:
+      integrity: sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz'
+    version: 15.7.2
+  registry.npmjs.org/react-dom/16.3.2_react@16.3.2:
+    dependencies:
+      fbjs: registry.npmjs.org/fbjs/0.8.17
+      loose-envify: registry.npmjs.org/loose-envify/1.4.0
+      object-assign: registry.npmjs.org/object-assign/4.1.1
+      prop-types: registry.npmjs.org/prop-types/15.7.2
+      react: registry.npmjs.org/react/16.3.2
+    deprecated: 'This version of react-dom/server contains a minor vulnerability. Please update react-dom to 16.3.3 or 16.4.2+. Learn more: https://fb.me/cve-2018-6341'
+    dev: false
+    id: registry.npmjs.org/react-dom/16.3.2
+    name: react-dom
+    peerDependencies:
+      react: ^16.0.0
+    resolution:
+      integrity: sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz'
+    version: 16.3.2
+  registry.npmjs.org/react-is/16.13.1:
+    dev: false
+    name: react-is
+    resolution:
+      integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz'
+    version: 16.13.1
+  registry.npmjs.org/react/16.3.2:
+    dependencies:
+      fbjs: registry.npmjs.org/fbjs/0.8.17
+      loose-envify: registry.npmjs.org/loose-envify/1.4.0
+      object-assign: registry.npmjs.org/object-assign/4.1.1
+      prop-types: registry.npmjs.org/prop-types/15.7.2
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    name: react
+    resolution:
+      integrity: sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/react/-/react-16.3.2.tgz'
+    version: 16.3.2
+  registry.npmjs.org/safer-buffer/2.1.2:
+    dev: false
+    name: safer-buffer
+    resolution:
+      integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz'
+    version: 2.1.2
+  registry.npmjs.org/setimmediate/1.0.5:
+    dev: false
+    name: setimmediate
+    resolution:
+      integrity: sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz'
+    version: 1.0.5
+  registry.npmjs.org/tslib/1.13.0:
+    dev: false
+    name: tslib
+    resolution:
+      integrity: sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz'
+    version: 1.13.0
+  registry.npmjs.org/ua-parser-js/0.7.21:
+    dev: false
+    name: ua-parser-js
+    resolution:
+      integrity: sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz'
+    version: 0.7.21
+  registry.npmjs.org/whatwg-fetch/3.2.0:
+    dev: false
+    name: whatwg-fetch
+    resolution:
+      integrity: sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w==
+      registry: 'https://registry.yarnpkg.com/'
+      tarball: 'https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz'
+    version: 3.2.0
+specifiers:
+  '@types/react': 16.3.12
+  '@types/react-dom': 16.0.5
+  office-ui-fabric-react: 5.88.0
+  react: 16.3.2
+  react-dom: 16.3.2


### PR DESCRIPTION
Provide a [devcontainer](https://code.visualstudio.com/docs/remote/containers) for ts-loader to make it easier for people to get up and running contributing.  

Also should allow for [codespaces](https://github.com/features/codespaces/) support when access is unlocked.