### PR TITLE
Support for no tsconfig.json

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -57,7 +57,6 @@ export function getConfigFile(
     configFile = {
       config: {
         compilerOptions: {},
-        files: [],
       },
     };
   }

--- a/test/comparison-tests/html-webpack-plugin-no-config/app.ts
+++ b/test/comparison-tests/html-webpack-plugin-no-config/app.ts
@@ -1,0 +1,1 @@
+console.log("hello");

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.6/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.6/bundle.js
@@ -1,0 +1,51 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	console.log("hello");
+
+
+/***/ }
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.6/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.6/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.6/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.6/output.txt
@@ -1,0 +1,12 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    1.41 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+chunk    {0} bundle.js (main) 22 bytes [rendered]
+    [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks       Chunk Names
+    index.html  534 kB       0       
+    chunk    {0} index.html 516 kB [rendered]
+        [0] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 550 bytes {0} [built]
+        [1] ./~/html-webpack-plugin/~/lodash/lodash.js 516 kB {0} [built]
+        [2] (webpack)/buildin/module.js 241 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.7/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.7/bundle.js
@@ -1,0 +1,51 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	console.log("hello");
+
+
+/***/ }
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.7/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.7/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.7/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.7/output.txt
@@ -1,0 +1,12 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    1.41 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+chunk    {0} bundle.js (main) 22 bytes [rendered]
+    [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks       Chunk Names
+    index.html  534 kB       0       
+    chunk    {0} index.html 516 kB [rendered]
+        [0] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 550 bytes {0} [built]
+        [1] ./~/html-webpack-plugin/~/lodash/lodash.js 516 kB {0} [built]
+        [2] (webpack)/buildin/module.js 241 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.8/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.8/bundle.js
@@ -1,0 +1,51 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	console.log("hello");
+
+
+/***/ }
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.8/bundle.transpiled.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.8/bundle.transpiled.js
@@ -1,0 +1,52 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	"use strict";
+	console.log("hello");
+
+
+/***/ }
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.8/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.8/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.8/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.8/output.transpiled.txt
@@ -1,0 +1,12 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    1.43 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+chunk    {0} bundle.js (main) 36 bytes [rendered]
+    [0] ./.test/html-webpack-plugin/app.ts 36 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks       Chunk Names
+    index.html  534 kB       0       
+    chunk    {0} index.html 516 kB [rendered]
+        [0] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 550 bytes {0} [built]
+        [1] ./~/html-webpack-plugin/~/lodash/lodash.js 516 kB {0} [built]
+        [2] (webpack)/buildin/module.js 241 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.8/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-1.8/output.txt
@@ -1,0 +1,12 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    1.41 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+chunk    {0} bundle.js (main) 22 bytes [rendered]
+    [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks       Chunk Names
+    index.html  534 kB       0       
+    chunk    {0} index.html 516 kB [rendered]
+        [0] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 550 bytes {0} [built]
+        [1] ./~/html-webpack-plugin/~/lodash/lodash.js 516 kB {0} [built]
+        [2] (webpack)/buildin/module.js 241 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.0/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.0/bundle.js
@@ -1,0 +1,51 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	console.log("hello");
+
+
+/***/ }
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.0/bundle.transpiled.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.0/bundle.transpiled.js
@@ -1,0 +1,52 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports) {
+
+	"use strict";
+	console.log("hello");
+
+
+/***/ }
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.0/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.0/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.0/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.0/output.transpiled.txt
@@ -1,0 +1,12 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    1.43 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+chunk    {0} bundle.js (main) 36 bytes [rendered]
+    [0] ./.test/html-webpack-plugin/app.ts 36 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks       Chunk Names
+    index.html  558 kB       0       
+    chunk    {0} index.html 540 kB [rendered]
+        [0] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 540 bytes {0} [built]
+        [1] ./~/lodash/lodash.js 539 kB {0} [built]
+        [2] (webpack)/buildin/module.js 241 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.0/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.0/output.txt
@@ -1,0 +1,12 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    1.41 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+chunk    {0} bundle.js (main) 22 bytes [rendered]
+    [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks       Chunk Names
+    index.html  558 kB       0       
+    chunk    {0} index.html 540 kB [rendered]
+        [0] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 540 bytes {0} [built]
+        [1] ./~/lodash/lodash.js 539 kB {0} [built]
+        [2] (webpack)/buildin/module.js 241 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.1/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.1/bundle.js
@@ -1,0 +1,77 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports) {
+
+console.log("hello");
+
+
+/***/ })
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.1/bundle.transpiled.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.1/bundle.transpiled.js
@@ -1,0 +1,79 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+console.log("hello");
+
+
+/***/ })
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.1/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.1/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.1/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.1/output.transpiled.txt
@@ -1,0 +1,13 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.57 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+chunk    {0} bundle.js (main) 36 bytes [entry] [rendered]
+    [0] ./.test/html-webpack-plugin/app.ts 36 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks  Chunk Names
+    index.html  544 kB       0  
+    chunk    {0} index.html 541 kB [entry] [rendered]
+        [0] ./~/lodash/lodash.js 540 kB {0} [built]
+        [1] (webpack)/buildin/global.js 488 bytes {0} [built]
+        [2] (webpack)/buildin/module.js 495 bytes {0} [built]
+        [3] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 540 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.1/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.1/output.txt
@@ -1,0 +1,13 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.53 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+chunk    {0} bundle.js (main) 22 bytes [entry] [rendered]
+    [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks  Chunk Names
+    index.html  544 kB       0  
+    chunk    {0} index.html 541 kB [entry] [rendered]
+        [0] ./~/lodash/lodash.js 540 kB {0} [built]
+        [1] (webpack)/buildin/global.js 488 bytes {0} [built]
+        [2] (webpack)/buildin/module.js 495 bytes {0} [built]
+        [3] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 540 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.2/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.2/bundle.js
@@ -1,0 +1,77 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports) {
+
+console.log("hello");
+
+
+/***/ })
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.2/bundle.transpiled.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.2/bundle.transpiled.js
@@ -1,0 +1,80 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+exports.__esModule = true;
+console.log("hello");
+
+
+/***/ })
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.2/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.2/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.2/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.2/output.transpiled.txt
@@ -1,0 +1,13 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.72 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+chunk    {0} bundle.js (main) 63 bytes [entry] [rendered]
+    [0] ./.test/html-webpack-plugin/app.ts 63 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks  Chunk Names
+    index.html  544 kB       0  
+    chunk    {0} index.html 541 kB [entry] [rendered]
+        [0] ./~/lodash/lodash.js 540 kB {0} [built]
+        [1] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 538 bytes {0} [built]
+        [2] (webpack)/buildin/global.js 488 bytes {0} [built]
+        [3] (webpack)/buildin/module.js 495 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.2/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.2/output.txt
@@ -1,0 +1,13 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.66 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+chunk    {0} bundle.js (main) 22 bytes [entry] [rendered]
+    [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks  Chunk Names
+    index.html  544 kB       0  
+    chunk    {0} index.html 541 kB [entry] [rendered]
+        [0] ./~/lodash/lodash.js 540 kB {0} [built]
+        [1] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 538 bytes {0} [built]
+        [2] (webpack)/buildin/global.js 488 bytes {0} [built]
+        [3] (webpack)/buildin/module.js 495 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.3/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.3/bundle.js
@@ -1,0 +1,77 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports) {
+
+console.log("hello");
+
+
+/***/ })
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.3/bundle.transpiled.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.3/bundle.transpiled.js
@@ -1,0 +1,80 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+exports.__esModule = true;
+console.log("hello");
+
+
+/***/ })
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.3/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.3/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.3/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.3/output.transpiled.txt
@@ -1,0 +1,13 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.72 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+chunk    {0} bundle.js (main) 63 bytes [entry] [rendered]
+    [0] ./.test/html-webpack-plugin/app.ts 63 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks  Chunk Names
+    index.html  544 kB       0  
+    chunk    {0} index.html 541 kB [entry] [rendered]
+        [0] ./~/lodash/lodash.js 540 kB {0} [built]
+        [1] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 538 bytes {0} [built]
+        [2] (webpack)/buildin/global.js 488 bytes {0} [built]
+        [3] (webpack)/buildin/module.js 495 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.3/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.3/output.txt
@@ -1,0 +1,13 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.66 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+chunk    {0} bundle.js (main) 22 bytes [entry] [rendered]
+    [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks  Chunk Names
+    index.html  544 kB       0  
+    chunk    {0} index.html 541 kB [entry] [rendered]
+        [0] ./~/lodash/lodash.js 540 kB {0} [built]
+        [1] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 538 bytes {0} [built]
+        [2] (webpack)/buildin/global.js 488 bytes {0} [built]
+        [3] (webpack)/buildin/module.js 495 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.4/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.4/bundle.js
@@ -1,0 +1,77 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports) {
+
+console.log("hello");
+
+
+/***/ })
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.4/bundle.transpiled.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.4/bundle.transpiled.js
@@ -1,0 +1,80 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+exports.__esModule = true;
+console.log("hello");
+
+
+/***/ })
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.4/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.4/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.4/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.4/output.transpiled.txt
@@ -1,0 +1,13 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.72 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+chunk    {0} bundle.js (main) 63 bytes [entry] [rendered]
+    [0] ./.test/html-webpack-plugin/app.ts 63 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks  Chunk Names
+    index.html  544 kB       0  
+    chunk    {0} index.html 541 kB [entry] [rendered]
+        [0] ./~/lodash/lodash.js 540 kB {0} [built]
+        [1] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 538 bytes {0} [built]
+        [2] (webpack)/buildin/global.js 488 bytes {0} [built]
+        [3] (webpack)/buildin/module.js 495 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.4/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.4/output.txt
@@ -1,0 +1,13 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.66 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+chunk    {0} bundle.js (main) 22 bytes [entry] [rendered]
+    [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks  Chunk Names
+    index.html  544 kB       0  
+    chunk    {0} index.html 541 kB [entry] [rendered]
+        [0] ./~/lodash/lodash.js 540 kB {0} [built]
+        [1] ./~/html-webpack-plugin/lib/loader.js!./~/html-webpack-plugin/default_index.ejs 538 bytes {0} [built]
+        [2] (webpack)/buildin/global.js 488 bytes {0} [built]
+        [3] (webpack)/buildin/module.js 495 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.5/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.5/bundle.js
@@ -1,0 +1,74 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports) {
+
+console.log("hello");
+
+
+/***/ })
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.5/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.5/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.5/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.5/output.txt
@@ -1,0 +1,11 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js     2.5 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+   [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks  Chunk Names
+    index.html  544 kB       0  
+       [0] ./node_modules/html-webpack-plugin/lib/loader.js!./node_modules/html-webpack-plugin/default_index.ejs 538 bytes {0} [built]
+       [1] ./node_modules/lodash/lodash.js 540 kB {0} [built]
+       [2] (webpack)/buildin/global.js 488 bytes {0} [built]
+       [3] (webpack)/buildin/module.js 495 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.6/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.6/bundle.js
@@ -1,0 +1,74 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports) {
+
+console.log("hello");
+
+
+/***/ })
+/******/ ]);

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.6/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.6/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.6/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.6/output.txt
@@ -1,0 +1,11 @@
+     Asset       Size  Chunks             Chunk Names
+ bundle.js     2.5 kB       0  [emitted]  main
+index.html  182 bytes          [emitted]  
+   [0] ./.test/html-webpack-plugin/app.ts 22 bytes {0} [built]
+Child html-webpack-plugin for "index.html":
+         Asset    Size  Chunks  Chunk Names
+    index.html  544 kB       0  
+       [0] ./node_modules/html-webpack-plugin/lib/loader.js!./node_modules/html-webpack-plugin/default_index.ejs 538 bytes {0} [built]
+       [1] ./node_modules/lodash/lodash.js 540 kB {0} [built]
+       [2] (webpack)/buildin/global.js 488 bytes {0} [built]
+       [3] (webpack)/buildin/module.js 495 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.7/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.7/bundle.js
@@ -1,0 +1,85 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("console.log(\"hello\");\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.7/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.7/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.7/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.7/output.transpiled.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:14
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.7/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.7/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:12
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.8/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.8/bundle.js
@@ -1,0 +1,85 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("console.log(\"hello\");\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.8/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.8/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.8/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.8/output.transpiled.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:14
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.8/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.8/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:12
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.9/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.9/bundle.js
@@ -1,0 +1,85 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("console.log(\"hello\");\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.9/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.9/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.9/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.9/output.transpiled.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:14
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.9/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-2.9/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:12
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.0/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.0/bundle.js
@@ -1,0 +1,85 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("console.log(\"hello\");\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.0/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.0/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.0/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.0/output.transpiled.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:14
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.0/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.0/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:12
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.1/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.1/bundle.js
@@ -1,0 +1,85 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("console.log(\"hello\");\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.1/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.1/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.1/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.1/output.transpiled.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:14
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.1/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.1/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:12
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.2/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.2/bundle.js
@@ -1,0 +1,85 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("console.log(\"hello\");\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.2/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.2/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.2/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.2/output.transpiled.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:14
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.2/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.2/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:12
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.3/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.3/bundle.js
@@ -1,0 +1,85 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("console.log(\"hello\");\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.3/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.3/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.3/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.3/output.transpiled.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:14
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.3/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.3/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:12
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.4/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.4/bundle.js
@@ -1,0 +1,85 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("console.log(\"hello\");\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.4/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.4/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.4/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.4/output.transpiled.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:14
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.4/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.4/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:12
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.5/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.5/bundle.js
@@ -1,0 +1,85 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("console.log(\"hello\");\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.5/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.5/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.5/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.5/output.transpiled.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:14
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.5/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.5/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:12
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.6/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.6/bundle.js
@@ -1,0 +1,85 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("console.log(\"hello\");\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.6/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.6/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.6/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.6/output.transpiled.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:14
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.6/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.6/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:12
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.7/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.7/bundle.js
@@ -1,0 +1,85 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("console.log(\"hello\");\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.7/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.7/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.7/output.transpiled.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.7/output.transpiled.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:14
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.7/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.7/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:12
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.8/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.8/bundle.js
@@ -1,0 +1,85 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("console.log(\"hello\");\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.8/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.8/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.8/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.8/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:12
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.9/bundle.js
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.9/bundle.js
@@ -1,0 +1,85 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("console.log(\"hello\");\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.9/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.9/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script type="text/javascript" src="bundle.js"></script></body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.9/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-3.9/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:12
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-transpile-3.8/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-transpile-3.8/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:14
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-transpile-3.9/output.txt
+++ b/test/comparison-tests/html-webpack-plugin-no-config/expectedOutput-transpile-3.9/output.txt
@@ -1,0 +1,14 @@
+Built at: 2018-3-18 09:18:14
+     Asset       Size  Chunks             Chunk Names
+ bundle.js    2.8 KiB    main  [emitted]  main
+index.html  190 bytes          [emitted]  
+Entrypoint main = bundle.js
+[./app.ts] 22 bytes {main} [built]
+Child html-webpack-plugin for "index.html":
+         Asset     Size  Chunks  Chunk Names
+    index.html  550 KiB       0  
+    Entrypoint undefined = index.html
+    [../../node_modules/html-webpack-plugin/lib/loader.js!./index.html] /node_modules/html-webpack-plugin/lib/loader.js!./index.html 509 bytes {0} [built]
+    [../../node_modules/lodash/lodash.js] /node_modules/lodash/lodash.js 527 KiB {0} [built]
+    [../../node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 489 bytes {0} [built]
+    [../../node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]

--- a/test/comparison-tests/html-webpack-plugin-no-config/index.html
+++ b/test/comparison-tests/html-webpack-plugin-no-config/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  </body>
+</html>

--- a/test/comparison-tests/html-webpack-plugin-no-config/tsconfig.json
+++ b/test/comparison-tests/html-webpack-plugin-no-config/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"compilerOptions": {
+	}
+}


### PR DESCRIPTION
This fixes an the following error when no tsconfig.json is provided:

```
The 'files' list in config file 'tsconfig.json' is empty.
```

Reference: https://github.com/TypeStrong/ts-loader/issues/1063

Includes a version of the webpack test without a tsconfig.json