### PR TITLE
Fix getOptionsHash when two options has different props but same values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v8.0.3
+* [Fix the wrong instance caching when using `appendTsSuffixTo` and `appendTsxSuffixTo` together](https://github.com/TypeStrong/ts-loader/pull/1170) - thanks @meowtec
+
 ## v8.0.2
 
 * [Fix 2 issues with experimentalWatchApi](https://github.com/TypeStrong/ts-loader/pull/1159) - thanks @appzuka

--- a/README.md
+++ b/README.md
@@ -498,14 +498,23 @@ of your code.
 #### appendTsSuffixTo
 | Type | Default Value |
 |------|--------------|
-| `RegExp[]` | `[]`|
+| `(RegExp | string)[]` | `[]`|
 
 #### appendTsxSuffixTo
 | Type | Default Value |
 |------|--------------|
-| `RegExp[]` | `[]`|
+| `(RegExp | string)[]` | `[]`|
 
 A list of regular expressions to be matched against filename. If filename matches one of the regular expressions, a `.ts` or `.tsx` suffix will be appended to that filename.
+If you're using [HappyPack](https://github.com/amireh/happypack) or [thread-loader](https://github.com/webpack-contrib/thread-loader) with `ts-loader`, you need use the `string` type for the regular expressions, not `RegExp` object.
+
+```js
+// change this:
+{ appendTsSuffixTo: [/\.vue$/] }
+// to:
+{ appendTsSuffixTo: ['\\.vue$'] }
+```
+
 
 This is useful for `*.vue` [file format](https://vuejs.org/v2/guide/single-file-components.html) for now. (Probably will benefit from the new single file format in the future.)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,7 +160,7 @@ function setModuleMeta(
  */
 function getOptionsHash(loaderOptions: LoaderOptions) {
   const hash = crypto.createHash('sha256');
-  Object.keys(loaderOptions).map(key => {
+  Object.keys(loaderOptions).forEach(key => {
     const value = loaderOptions[key];
     if (value) {
       hash.update(key + value.toString());

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,9 +160,10 @@ function setModuleMeta(
  */
 function getOptionsHash(loaderOptions: LoaderOptions) {
   const hash = crypto.createHash('sha256');
-  Object.values(loaderOptions).map((v: any) => {
-    if (v) {
-      hash.update(v.toString());
+  Object.keys(loaderOptions).map(key => {
+    const value = loaderOptions[key];
+    if (value) {
+      hash.update(key + value.toString());
     }
   });
   return hash.digest('hex').substring(0, 16);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -266,8 +266,8 @@ export interface LoaderOptions {
   onlyCompileBundledFiles: boolean;
   colors: boolean;
   compilerOptions: typescript.CompilerOptions;
-  appendTsSuffixTo: RegExp[];
-  appendTsxSuffixTo: RegExp[];
+  appendTsSuffixTo: (RegExp | string)[];
+  appendTsxSuffixTo: (RegExp | string)[];
   happyPackMode: boolean;
   getCustomTransformers:
     | string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -137,7 +137,7 @@ export function makeError(
 }
 
 export function appendSuffixIfMatch(
-  patterns: RegExp[],
+  patterns: (RegExp | string)[],
   filePath: string,
   suffix: string
 ): string {
@@ -152,7 +152,7 @@ export function appendSuffixIfMatch(
 }
 
 export function appendSuffixesIfMatch(
-  suffixDict: { [suffix: string]: RegExp[] },
+  suffixDict: { [suffix: string]: (RegExp | string)[] },
   filePath: string
 ): string {
   let amendedPath = filePath;


### PR DESCRIPTION
Fix the issue when I use both `lang="tsx"` and `lang="ts"` in vue single file components.
For `lang="ts"`: 
```
{
  appendTsSuffixTo: [/\.vue$/],
  transpileOnly: true,
}
```

For `lang="tsx"`: 
```
{
  appendTsxSuffixTo: [/\.vue$/],
  transpileOnly: true,
}
```

They get the same hash because `getOptionsHash` use only values for hashing.
So for tsx vue file, it reuses the loader options which is only for ts vue, which add `.ts` suffix not `.tsx`.
That can lead to wrong compilation result.
