### PR TITLE
Shares solution builder between instances

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -129,10 +129,12 @@ export interface SolutionBuilderWithWatchHost
       typescript.EmitAndSemanticDiagnosticsBuilderProgram
     >,
     WatchFactory {
+  defaultInstance: TSInstance;
+  instances: Map<string, TSInstance>;
   diagnostics: SolutionDiagnostics;
   writtenFiles: OutputFile[];
   configFileInfo: Map<FilePathKey, ConfigFileInfo>;
-  outputAffectingInstanceVersion: Map<FilePathKey, true>;
+  outputAffectingInstanceVersion: Map<string, Map<FilePathKey, true>>;
   getOutputFileKeyFromReferencedProject(
     outputFileName: string
   ): FilePathKey | undefined;
@@ -204,9 +206,6 @@ export interface TSInstance {
 
   reportTranspileErrors?: boolean;
   solutionBuilderHost?: SolutionBuilderWithWatchHost;
-  solutionBuilder?: typescript.SolutionBuilder<
-    typescript.EmitAndSemanticDiagnosticsBuilderProgram
-  >;
   configFilePath: string | undefined;
 
   filePathKeyMapper: (fileName: string) => FilePathKey;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,6 +100,7 @@ export function formatErrors(
               : loaderOptions.errorFormatter(errorInfo, colors);
 
           const error = makeError(
+            loaderOptions,
             message,
             merge.file === undefined ? errorInfo.file : merge.file,
             position === undefined
@@ -124,6 +125,7 @@ export function fsReadFile(
 }
 
 export function makeError(
+  loaderOptions: LoaderOptions,
   message: string,
   file: string | undefined,
   location?: { line: number; character: number }
@@ -132,8 +134,12 @@ export function makeError(
     message,
     location,
     file,
-    loaderSource: 'ts-loader',
+    loaderSource: tsLoaderSource(loaderOptions),
   };
+}
+
+export function tsLoaderSource(loaderOptions: LoaderOptions) {
+  return `ts-loader-${loaderOptions.instance}`;
 }
 
 export function appendSuffixIfMatch(
@@ -281,10 +287,7 @@ export function ensureProgram(instance: TSInstance) {
 
 export function supportsSolutionBuild(instance: TSInstance) {
   return (
-    !!instance.configFilePath &&
-    !!instance.loaderOptions.projectReferences &&
-    !!instance.configParseResult.projectReferences &&
-    !!instance.configParseResult.projectReferences.length
+    !!instance.configFilePath && !!instance.loaderOptions.projectReferences
   );
 }
 

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/app/app.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/app/app.ts
@@ -1,0 +1,5 @@
+import { lib } from '../lib';
+import { utils } from "../utils";
+
+console.log(lib.one, lib.two, lib.three);
+utils();

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/app/tsconfig.json
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/app/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "types": []
+    },
+    "files": [
+        "./app.ts"
+    ],
+    "references": [
+        { "path": "../lib" },
+        { "path": "../utils" },
+    ]
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/app/webpack.config.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/app/webpack.config.js
@@ -1,0 +1,22 @@
+var path = require('path')
+
+module.exports = {
+    mode: 'development',
+    entry: './app.ts',
+    output: {
+        filename: 'bundle.js'
+    },
+    resolve: {
+        extensions: ['.ts', '.js']
+    },
+    module: {
+        rules: [
+            { test: /(app|lib|common|indirect).+\.ts$/, loader: 'ts-loader', options: { projectReferences: true } },
+            { test: /utils.+\.ts$/, loader: 'ts-loader', options: { instance: 'different', projectReferences: true } }
+        ]
+    }
+}
+
+// for test harness purposes only, you would not need this in a normal project
+module.exports.resolveLoader = { alias: { 'ts-loader': require('path').join(__dirname, "../../../../index.js") } }
+

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/common/index.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/common/index.ts
@@ -1,0 +1,3 @@
+export function common() {
+  return 30;
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/common/tsconfig.json
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/common/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "types": []
+  }
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 30;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/common/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/common/index.d.ts
@@ -1,0 +1,1 @@
+export declare function common(): number;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/common/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/common/index.js
@@ -1,0 +1,7 @@
+"use strict";
+exports.__esModule = true;
+exports.common = void 0;
+function common() {
+    return 30;
+}
+exports.common = common;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/common/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/common/tsconfig.tsbuildinfo
@@ -1,0 +1,55 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "./index.ts": {
+        "version": "83a8bcfe78ca61ceac765c205ef0435e93f65e7bc386ea12d21e0c963a7e824e",
+        "signature": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/indirect/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/indirect/index.d.ts
@@ -1,0 +1,5 @@
+export declare const lib: {
+    one: number;
+    two: number;
+    three: number;
+};

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/indirect/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/indirect/index.js
@@ -1,0 +1,8 @@
+"use strict";
+exports.__esModule = true;
+exports.lib = void 0;
+exports.lib = {
+    one: 1,
+    two: 2,
+    three: 3
+};

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/indirect/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/indirect/tsconfig.tsbuildinfo
@@ -1,0 +1,55 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "./index.ts": {
+        "version": "28ead8445f54a115ea5f778da4f4f80579fbae42ac6ccc3493626084ed335839",
+        "signature": "82b9c263edd140802d0afbd57d557b2c41db16c5ad9a744bca8c71ad5b10f66f",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/lib/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/lib/index.d.ts
@@ -1,0 +1,5 @@
+export declare const lib: {
+    one: number;
+    two: number;
+    three: number;
+};

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/lib/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/lib/index.js
@@ -1,0 +1,8 @@
+"use strict";
+exports.__esModule = true;
+exports.lib = void 0;
+exports.lib = {
+    one: 1,
+    two: 2,
+    three: 3
+};

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/lib/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/lib/tsconfig.tsbuildinfo
@@ -1,0 +1,55 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "./index.ts": {
+        "version": "28ead8445f54a115ea5f778da4f4f80579fbae42ac6ccc3493626084ed335839",
+        "signature": "82b9c263edd140802d0afbd57d557b2c41db16c5ad9a744bca8c71ad5b10f66f",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/output.txt
@@ -1,0 +1,19 @@
+                           Asset       Size  Chunks             Chunk Names
+            ../common/index.d.ts   42 bytes          [emitted]  
+              ../common/index.js  128 bytes          [emitted]  
+  ../common/tsconfig.tsbuildinfo   2.32 KiB          [emitted]  
+          ../indirect/index.d.ts   84 bytes          [emitted]  
+            ../indirect/index.js  119 bytes          [emitted]  
+../indirect/tsconfig.tsbuildinfo   2.32 KiB          [emitted]  
+               ../lib/index.d.ts   84 bytes          [emitted]  
+                 ../lib/index.js  119 bytes          [emitted]  
+     ../lib/tsconfig.tsbuildinfo   2.32 KiB          [emitted]  
+             ../utils/index.d.ts   39 bytes          [emitted]  
+               ../utils/index.js  169 bytes          [emitted]  
+   ../utils/tsconfig.tsbuildinfo   2.66 KiB          [emitted]  
+                       bundle.js   5.48 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 41 bytes {main} [built]
+[../lib/index.ts] 55 bytes {main} [built]
+[../utils/index.ts] 169 bytes {main} [built]
+[./app.ts] 184 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch0/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch0/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 35;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch0/common/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch0/common/index.d.ts
@@ -1,0 +1,1 @@
+export declare function common(): number;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch0/common/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch0/common/index.js
@@ -1,0 +1,7 @@
+"use strict";
+exports.__esModule = true;
+exports.common = void 0;
+function common() {
+    return 35;
+}
+exports.common = common;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch0/common/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch0/common/tsconfig.tsbuildinfo
@@ -1,0 +1,55 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "./index.ts": {
+        "version": "ea4f1fab5d827d59b4b09d9e42b615faf16b08c259290b9fcb5982bb9543bd52",
+        "signature": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch0/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch0/output.txt
@@ -1,0 +1,10 @@
+                         Asset       Size  Chunks             Chunk Names
+          ../common/index.d.ts   42 bytes          [emitted]  
+            ../common/index.js  128 bytes          [emitted]  
+../common/tsconfig.tsbuildinfo   2.32 KiB          [emitted]  
+                     bundle.js   5.29 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 128 bytes {main} [built]
+[../lib/index.ts] 119 bytes {main}
+[../utils/index.ts] 169 bytes {main} [built]
+[./app.ts] 184 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch1/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch1/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 35;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils2 = exports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\nfunction utils2() { return \"hello\"; }\nexports.utils2 = utils2;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch1/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch1/output.txt
@@ -1,0 +1,10 @@
+                        Asset       Size  Chunks             Chunk Names
+          ../utils/index.d.ts   81 bytes          [emitted]  
+            ../utils/index.js  249 bytes          [emitted]  
+../utils/tsconfig.tsbuildinfo   2.66 KiB          [emitted]  
+                    bundle.js   5.57 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 41 bytes {main}
+[../lib/index.ts] 55 bytes {main}
+[../utils/index.ts] 249 bytes {main} [built]
+[./app.ts] 184 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch1/utils/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch1/utils/index.d.ts
@@ -1,0 +1,2 @@
+export declare function utils(): void;
+export declare function utils2(): string;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch1/utils/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch1/utils/index.js
@@ -1,0 +1,10 @@
+"use strict";
+exports.__esModule = true;
+exports.utils2 = exports.utils = void 0;
+var common_1 = require("../common");
+function utils() {
+    common_1.common();
+}
+exports.utils = utils;
+function utils2() { return "hello"; }
+exports.utils2 = utils2;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch1/utils/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch1/utils/tsconfig.tsbuildinfo
@@ -1,0 +1,65 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "../common/index.d.ts": {
+        "version": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "signature": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "affectsGlobalScope": false
+      },
+      "./index.ts": {
+        "version": "a1dbdf6843733c9641c0dccfc0fd2ac2bc4cb630b60143672e64e0a65a8dbb7a",
+        "signature": "965912a69421fffc4b79247cd826f3e8bdb5cdbd3ab8d0b5ca57e5a40cfc5869",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {
+      "./index.ts": [
+        "../common/index.d.ts"
+      ]
+    },
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../common/index.d.ts",
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch2/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch2/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 35;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils2 = exports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\nfunction utils2() { return \"hello\"; }\nexports.utils2 = utils2;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\nutils_1.utils2();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch2/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch2/output.txt
@@ -1,0 +1,7 @@
+    Asset      Size  Chunks             Chunk Names
+bundle.js  5.58 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 41 bytes {main}
+[../lib/index.ts] 55 bytes {main}
+[../utils/index.ts] 249 bytes {main}
+[./app.ts] 202 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch3/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch3/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 35;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils2 = exports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\nfunction utils2() { return \"hello\"; }\nexports.utils2 = utils2;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\nutils_1.utils2();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch3/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch3/output.txt
@@ -1,0 +1,12 @@
+    Asset      Size  Chunks             Chunk Names
+bundle.js  5.39 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 128 bytes {main} [built] [1 error]
+[../lib/index.ts] 119 bytes {main}
+[../utils/index.ts] 249 bytes {main} [built]
+[./app.ts] 202 bytes {main} [built]
+
+ERROR in common\index.ts
+../common/index.ts
+[90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mcommon\index.ts(2,3)[39m[22m
+[1m[31m      TS2322: Type '35' is not assignable to type 'string'.[39m[22m

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch4/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch4/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 35;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils2 = exports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\nfunction utils2() { return \"hello\"; }\nexports.utils2 = utils2;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\nutils_1.utils2();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch4/common/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch4/common/index.d.ts
@@ -1,0 +1,1 @@
+export declare function common(): number;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch4/common/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch4/common/index.js
@@ -1,0 +1,7 @@
+"use strict";
+exports.__esModule = true;
+exports.common = void 0;
+function common() {
+    return 35;
+}
+exports.common = common;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch4/common/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch4/common/tsconfig.tsbuildinfo
@@ -1,0 +1,55 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "./index.ts": {
+        "version": "ea4f1fab5d827d59b4b09d9e42b615faf16b08c259290b9fcb5982bb9543bd52",
+        "signature": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch4/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch4/output.txt
@@ -1,0 +1,10 @@
+                         Asset       Size  Chunks             Chunk Names
+          ../common/index.d.ts   42 bytes          [emitted]  
+            ../common/index.js  128 bytes          [emitted]  
+../common/tsconfig.tsbuildinfo   2.32 KiB          [emitted]  
+                     bundle.js   5.39 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 128 bytes {main} [built]
+[../lib/index.ts] 119 bytes {main}
+[../utils/index.ts] 249 bytes {main} [built]
+[./app.ts] 202 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch5/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch5/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 35;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils2 = exports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\nfunction utils2() { return \"hello\"; }\nexports.utils2 = utils2;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\nutils_1.utils2();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch5/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch5/output.txt
@@ -1,0 +1,12 @@
+    Asset      Size  Chunks             Chunk Names
+bundle.js  5.39 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 128 bytes {main}
+[../lib/index.ts] 119 bytes {main}
+[../utils/index.ts] 249 bytes {main} [built] [1 error]
+[./app.ts] 202 bytes {main} [built]
+
+ERROR in utils\index.ts
+../utils/index.ts
+[90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mutils\index.ts(5,36)[39m[22m
+[1m[31m      TS2322: Type '"hello"' is not assignable to type 'number'.[39m[22m

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch6/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch6/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 35;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils2 = exports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\nfunction utils2() { return \"hello\"; }\nexports.utils2 = utils2;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\nutils_1.utils2();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch6/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch6/output.txt
@@ -1,0 +1,10 @@
+                        Asset       Size  Chunks             Chunk Names
+          ../utils/index.d.ts   81 bytes          [emitted]  
+            ../utils/index.js  249 bytes          [emitted]  
+../utils/tsconfig.tsbuildinfo   2.66 KiB          [emitted]  
+                    bundle.js   5.58 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 41 bytes {main}
+[../lib/index.ts] 55 bytes {main}
+[../utils/index.ts] 249 bytes {main} [built]
+[./app.ts] 202 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch6/utils/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch6/utils/index.d.ts
@@ -1,0 +1,2 @@
+export declare function utils(): void;
+export declare function utils2(): string;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch6/utils/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch6/utils/index.js
@@ -1,0 +1,10 @@
+"use strict";
+exports.__esModule = true;
+exports.utils2 = exports.utils = void 0;
+var common_1 = require("../common");
+function utils() {
+    common_1.common();
+}
+exports.utils = utils;
+function utils2() { return "hello"; }
+exports.utils2 = utils2;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch6/utils/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/patch6/utils/tsconfig.tsbuildinfo
@@ -1,0 +1,65 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "../common/index.d.ts": {
+        "version": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "signature": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "affectsGlobalScope": false
+      },
+      "./index.ts": {
+        "version": "a1dbdf6843733c9641c0dccfc0fd2ac2bc4cb630b60143672e64e0a65a8dbb7a",
+        "signature": "965912a69421fffc4b79247cd826f3e8bdb5cdbd3ab8d0b5ca57e5a40cfc5869",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {
+      "./index.ts": [
+        "../common/index.d.ts"
+      ]
+    },
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../common/index.d.ts",
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/utils/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/utils/index.d.ts
@@ -1,0 +1,1 @@
+export declare function utils(): void;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/utils/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/utils/index.js
@@ -1,0 +1,8 @@
+"use strict";
+exports.__esModule = true;
+exports.utils = void 0;
+var common_1 = require("../common");
+function utils() {
+    common_1.common();
+}
+exports.utils = utils;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/utils/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-3.9/utils/tsconfig.tsbuildinfo
@@ -1,0 +1,65 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "../common/index.d.ts": {
+        "version": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "signature": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "affectsGlobalScope": false
+      },
+      "./index.ts": {
+        "version": "4c7e50bd7f85cc5d64f963157685ca8eb1223e12466f47c719aaf1af32173088",
+        "signature": "2c471583ee40dd55eed961a2de47a5014f6639fa90572027eec9139c40293e19",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {
+      "./index.ts": [
+        "../common/index.d.ts"
+      ]
+    },
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../common/index.d.ts",
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 30;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nObject.defineProperty(exports, \"__esModule\", { value: true });\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/common/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/common/index.d.ts
@@ -1,0 +1,1 @@
+export declare function common(): number;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/common/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/common/index.js
@@ -1,0 +1,7 @@
+"use strict";
+exports.__esModule = true;
+exports.common = void 0;
+function common() {
+    return 30;
+}
+exports.common = common;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/common/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/common/tsconfig.tsbuildinfo
@@ -1,0 +1,55 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "./index.ts": {
+        "version": "83a8bcfe78ca61ceac765c205ef0435e93f65e7bc386ea12d21e0c963a7e824e",
+        "signature": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/indirect/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/indirect/index.d.ts
@@ -1,0 +1,5 @@
+export declare const lib: {
+    one: number;
+    two: number;
+    three: number;
+};

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/indirect/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/indirect/index.js
@@ -1,0 +1,8 @@
+"use strict";
+exports.__esModule = true;
+exports.lib = void 0;
+exports.lib = {
+    one: 1,
+    two: 2,
+    three: 3
+};

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/indirect/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/indirect/tsconfig.tsbuildinfo
@@ -1,0 +1,55 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "./index.ts": {
+        "version": "28ead8445f54a115ea5f778da4f4f80579fbae42ac6ccc3493626084ed335839",
+        "signature": "82b9c263edd140802d0afbd57d557b2c41db16c5ad9a744bca8c71ad5b10f66f",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/lib/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/lib/index.d.ts
@@ -1,0 +1,5 @@
+export declare const lib: {
+    one: number;
+    two: number;
+    three: number;
+};

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/lib/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/lib/index.js
@@ -1,0 +1,8 @@
+"use strict";
+exports.__esModule = true;
+exports.lib = void 0;
+exports.lib = {
+    one: 1,
+    two: 2,
+    three: 3
+};

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/lib/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/lib/tsconfig.tsbuildinfo
@@ -1,0 +1,55 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "./index.ts": {
+        "version": "28ead8445f54a115ea5f778da4f4f80579fbae42ac6ccc3493626084ed335839",
+        "signature": "82b9c263edd140802d0afbd57d557b2c41db16c5ad9a744bca8c71ad5b10f66f",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/output.txt
@@ -1,0 +1,19 @@
+                           Asset       Size  Chunks             Chunk Names
+            ../common/index.d.ts   42 bytes          [emitted]  
+              ../common/index.js  128 bytes          [emitted]  
+  ../common/tsconfig.tsbuildinfo   2.32 KiB          [emitted]  
+          ../indirect/index.d.ts   84 bytes          [emitted]  
+            ../indirect/index.js  119 bytes          [emitted]  
+../indirect/tsconfig.tsbuildinfo   2.32 KiB          [emitted]  
+               ../lib/index.d.ts   84 bytes          [emitted]  
+                 ../lib/index.js  119 bytes          [emitted]  
+     ../lib/tsconfig.tsbuildinfo   2.32 KiB          [emitted]  
+             ../utils/index.d.ts   39 bytes          [emitted]  
+               ../utils/index.js  169 bytes          [emitted]  
+   ../utils/tsconfig.tsbuildinfo   2.66 KiB          [emitted]  
+                       bundle.js   5.56 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 41 bytes {main} [built]
+[../lib/index.ts] 55 bytes {main} [built]
+[../utils/index.ts] 205 bytes {main} [built]
+[./app.ts] 220 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch0/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch0/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 35;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nObject.defineProperty(exports, \"__esModule\", { value: true });\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch0/common/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch0/common/index.d.ts
@@ -1,0 +1,1 @@
+export declare function common(): number;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch0/common/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch0/common/index.js
@@ -1,0 +1,7 @@
+"use strict";
+exports.__esModule = true;
+exports.common = void 0;
+function common() {
+    return 35;
+}
+exports.common = common;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch0/common/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch0/common/tsconfig.tsbuildinfo
@@ -1,0 +1,55 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "./index.ts": {
+        "version": "ea4f1fab5d827d59b4b09d9e42b615faf16b08c259290b9fcb5982bb9543bd52",
+        "signature": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch0/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch0/output.txt
@@ -1,0 +1,10 @@
+                         Asset       Size  Chunks             Chunk Names
+          ../common/index.d.ts   42 bytes          [emitted]  
+            ../common/index.js  128 bytes          [emitted]  
+../common/tsconfig.tsbuildinfo   2.32 KiB          [emitted]  
+                     bundle.js   5.56 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 41 bytes {main} [built]
+[../lib/index.ts] 55 bytes {main}
+[../utils/index.ts] 205 bytes {main} [built]
+[./app.ts] 220 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch1/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch1/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 35;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils2 = exports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\nfunction utils2() { return \"hello\"; }\nexports.utils2 = utils2;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nObject.defineProperty(exports, \"__esModule\", { value: true });\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch1/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch1/output.txt
@@ -1,0 +1,10 @@
+                        Asset       Size  Chunks             Chunk Names
+          ../utils/index.d.ts   81 bytes          [emitted]  
+            ../utils/index.js  249 bytes          [emitted]  
+../utils/tsconfig.tsbuildinfo   2.66 KiB          [emitted]  
+                    bundle.js   5.64 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 41 bytes {main}
+[../lib/index.ts] 55 bytes {main}
+[../utils/index.ts] 285 bytes {main} [built]
+[./app.ts] 220 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch1/utils/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch1/utils/index.d.ts
@@ -1,0 +1,2 @@
+export declare function utils(): void;
+export declare function utils2(): string;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch1/utils/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch1/utils/index.js
@@ -1,0 +1,10 @@
+"use strict";
+exports.__esModule = true;
+exports.utils2 = exports.utils = void 0;
+var common_1 = require("../common");
+function utils() {
+    common_1.common();
+}
+exports.utils = utils;
+function utils2() { return "hello"; }
+exports.utils2 = utils2;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch1/utils/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch1/utils/tsconfig.tsbuildinfo
@@ -1,0 +1,65 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "../common/index.d.ts": {
+        "version": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "signature": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "affectsGlobalScope": false
+      },
+      "./index.ts": {
+        "version": "a1dbdf6843733c9641c0dccfc0fd2ac2bc4cb630b60143672e64e0a65a8dbb7a",
+        "signature": "965912a69421fffc4b79247cd826f3e8bdb5cdbd3ab8d0b5ca57e5a40cfc5869",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {
+      "./index.ts": [
+        "../common/index.d.ts"
+      ]
+    },
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../common/index.d.ts",
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch2/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch2/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 35;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils2 = exports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\nfunction utils2() { return \"hello\"; }\nexports.utils2 = utils2;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nObject.defineProperty(exports, \"__esModule\", { value: true });\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\nutils_1.utils2();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch2/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch2/output.txt
@@ -1,0 +1,7 @@
+    Asset      Size  Chunks             Chunk Names
+bundle.js  5.66 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 41 bytes {main}
+[../lib/index.ts] 55 bytes {main}
+[../utils/index.ts] 285 bytes {main}
+[./app.ts] 238 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch3/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch3/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 35;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils2 = exports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\nfunction utils2() { return \"hello\"; }\nexports.utils2 = utils2;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nObject.defineProperty(exports, \"__esModule\", { value: true });\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\nutils_1.utils2();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch3/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch3/output.txt
@@ -1,0 +1,10 @@
+    Asset      Size  Chunks             Chunk Names
+bundle.js  5.43 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 128 bytes {main} [built]
+[../lib/index.ts] 119 bytes {main}
+[../utils/index.ts] 249 bytes {main} [built]
+[./app.ts] 238 bytes {main} [built] [1 error]
+
+ERROR in [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mcommon\index.ts(2,3)[39m[22m
+[1m[31m      TS2322: Type '35' is not assignable to type 'string'.[39m[22m

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch4/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch4/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 35;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils2 = exports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\nfunction utils2() { return \"hello\"; }\nexports.utils2 = utils2;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nObject.defineProperty(exports, \"__esModule\", { value: true });\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\nutils_1.utils2();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch4/common/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch4/common/index.d.ts
@@ -1,0 +1,1 @@
+export declare function common(): number;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch4/common/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch4/common/index.js
@@ -1,0 +1,7 @@
+"use strict";
+exports.__esModule = true;
+exports.common = void 0;
+function common() {
+    return 35;
+}
+exports.common = common;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch4/common/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch4/common/tsconfig.tsbuildinfo
@@ -1,0 +1,55 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "./index.ts": {
+        "version": "ea4f1fab5d827d59b4b09d9e42b615faf16b08c259290b9fcb5982bb9543bd52",
+        "signature": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch4/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch4/output.txt
@@ -1,0 +1,10 @@
+                         Asset       Size  Chunks             Chunk Names
+          ../common/index.d.ts   42 bytes          [emitted]  
+            ../common/index.js  128 bytes          [emitted]  
+../common/tsconfig.tsbuildinfo   2.32 KiB          [emitted]  
+                     bundle.js   5.66 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 41 bytes {main} [built]
+[../lib/index.ts] 55 bytes {main}
+[../utils/index.ts] 285 bytes {main} [built]
+[./app.ts] 238 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch5/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch5/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 35;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils2 = exports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\nfunction utils2() { return \"hello\"; }\nexports.utils2 = utils2;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nObject.defineProperty(exports, \"__esModule\", { value: true });\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\nutils_1.utils2();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch5/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch5/output.txt
@@ -1,0 +1,10 @@
+    Asset      Size  Chunks             Chunk Names
+bundle.js  5.66 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 41 bytes {main}
+[../lib/index.ts] 55 bytes {main}
+[../utils/index.ts] 285 bytes {main} [built]
+[./app.ts] 238 bytes {main} [built] [1 error]
+
+ERROR in [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mutils\index.ts(5,36)[39m[22m
+[1m[31m      TS2322: Type '"hello"' is not assignable to type 'number'.[39m[22m

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch6/app/bundle.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch6/app/bundle.js
@@ -1,0 +1,137 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "../common/index.ts":
+/*!**************************!*\
+  !*** ../common/index.ts ***!
+  \**************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.common = void 0;\nfunction common() {\n    return 35;\n}\nexports.common = common;\n\n\n//# sourceURL=webpack:///../common/index.ts?");
+
+/***/ }),
+
+/***/ "../lib/index.ts":
+/*!***********************!*\
+  !*** ../lib/index.ts ***!
+  \***********************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.lib = void 0;\nexports.lib = {\n    one: 1,\n    two: 2,\n    three: 3\n};\n\n\n//# sourceURL=webpack:///../lib/index.ts?");
+
+/***/ }),
+
+/***/ "../utils/index.ts":
+/*!*************************!*\
+  !*** ../utils/index.ts ***!
+  \*************************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nexports.__esModule = true;\nexports.utils2 = exports.utils = void 0;\nvar common_1 = __webpack_require__(/*! ../common */ \"../common/index.ts\");\nfunction utils() {\n    common_1.common();\n}\nexports.utils = utils;\nfunction utils2() { return \"hello\"; }\nexports.utils2 = utils2;\n\n\n//# sourceURL=webpack:///../utils/index.ts?");
+
+/***/ }),
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no static exports found */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+eval("\nObject.defineProperty(exports, \"__esModule\", { value: true });\nvar lib_1 = __webpack_require__(/*! ../lib */ \"../lib/index.ts\");\nvar utils_1 = __webpack_require__(/*! ../utils */ \"../utils/index.ts\");\nconsole.log(lib_1.lib.one, lib_1.lib.two, lib_1.lib.three);\nutils_1.utils();\nutils_1.utils2();\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch6/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch6/output.txt
@@ -1,0 +1,10 @@
+                        Asset       Size  Chunks             Chunk Names
+          ../utils/index.d.ts   81 bytes          [emitted]  
+            ../utils/index.js  249 bytes          [emitted]  
+../utils/tsconfig.tsbuildinfo   2.66 KiB          [emitted]  
+                    bundle.js   5.66 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[../common/index.ts] 41 bytes {main}
+[../lib/index.ts] 55 bytes {main}
+[../utils/index.ts] 285 bytes {main} [built]
+[./app.ts] 238 bytes {main} [built]

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch6/utils/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch6/utils/index.d.ts
@@ -1,0 +1,2 @@
+export declare function utils(): void;
+export declare function utils2(): string;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch6/utils/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch6/utils/index.js
@@ -1,0 +1,10 @@
+"use strict";
+exports.__esModule = true;
+exports.utils2 = exports.utils = void 0;
+var common_1 = require("../common");
+function utils() {
+    common_1.common();
+}
+exports.utils = utils;
+function utils2() { return "hello"; }
+exports.utils2 = utils2;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch6/utils/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/patch6/utils/tsconfig.tsbuildinfo
@@ -1,0 +1,65 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "../common/index.d.ts": {
+        "version": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "signature": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "affectsGlobalScope": false
+      },
+      "./index.ts": {
+        "version": "a1dbdf6843733c9641c0dccfc0fd2ac2bc4cb630b60143672e64e0a65a8dbb7a",
+        "signature": "965912a69421fffc4b79247cd826f3e8bdb5cdbd3ab8d0b5ca57e5a40cfc5869",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {
+      "./index.ts": [
+        "../common/index.d.ts"
+      ]
+    },
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../common/index.d.ts",
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/utils/index.d.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/utils/index.d.ts
@@ -1,0 +1,1 @@
+export declare function utils(): void;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/utils/index.js
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/utils/index.js
@@ -1,0 +1,8 @@
+"use strict";
+exports.__esModule = true;
+exports.utils = void 0;
+var common_1 = require("../common");
+function utils() {
+    common_1.common();
+}
+exports.utils = utils;

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/utils/tsconfig.tsbuildinfo
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-transpile-3.9/utils/tsconfig.tsbuildinfo
@@ -1,0 +1,65 @@
+{
+  "program": {
+    "fileInfos": {
+      "../../../node_modules/typescript/lib/lib.d.ts": {
+        "version": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "signature": "2dc8c927c9c162a773c6bb3cdc4f3286c23f10eedc67414028f9cb5951610f60",
+        "affectsGlobalScope": false
+      },
+      "../../../node_modules/typescript/lib/lib.es5.d.ts": {
+        "version": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "signature": "70ae6416528e68c2ee7b62892200d2ca631759943d4429f8b779b947ff1e124d",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.dom.d.ts": {
+        "version": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "signature": "9affb0a2ddc57df5b8174c0af96c288d697a262e5bc9ca1f544c999dc64a91e6",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts": {
+        "version": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "signature": "7fac8cb5fc820bc2a59ae11ef1c5b38d3832c6d0dfaec5acdb5569137d09a481",
+        "affectsGlobalScope": true
+      },
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts": {
+        "version": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "signature": "097a57355ded99c68e6df1b738990448e0bf170e606707df5a7c0481ff2427cd",
+        "affectsGlobalScope": true
+      },
+      "../common/index.d.ts": {
+        "version": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "signature": "43a7b48da056d56d751b52b1b22e1445fe52b56355f0adcbfd52c12ddc3e3ecb",
+        "affectsGlobalScope": false
+      },
+      "./index.ts": {
+        "version": "4c7e50bd7f85cc5d64f963157685ca8eb1223e12466f47c719aaf1af32173088",
+        "signature": "2c471583ee40dd55eed961a2de47a5014f6639fa90572027eec9139c40293e19",
+        "affectsGlobalScope": false
+      }
+    },
+    "options": {
+      "composite": true,
+      "types": [],
+      "newLine": 1,
+      "configFilePath": "./tsconfig.json",
+      "skipLibCheck": true,
+      "suppressOutputPathCheck": true
+    },
+    "referencedMap": {
+      "./index.ts": [
+        "../common/index.d.ts"
+      ]
+    },
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../common/index.d.ts",
+      "./index.ts",
+      "../../../node_modules/typescript/lib/lib.d.ts",
+      "../../../node_modules/typescript/lib/lib.dom.d.ts",
+      "../../../node_modules/typescript/lib/lib.es5.d.ts",
+      "../../../node_modules/typescript/lib/lib.scripthost.d.ts",
+      "../../../node_modules/typescript/lib/lib.webworker.importscripts.d.ts"
+    ]
+  },
+  "version": "3.9.3"
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/indirect/index.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/indirect/index.ts
@@ -1,0 +1,5 @@
+export const lib = {
+  one: 1,
+  two: 2,
+  three: 3
+};

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/indirect/tsconfig.json
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/indirect/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "types": []
+  }
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/lib/index.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/lib/index.ts
@@ -1,0 +1,5 @@
+export const lib = {
+  one: 1,
+  two: 2,
+  three: 3
+};

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/lib/tsconfig.json
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/lib/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "types": []
+  }
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/patch0/common/index.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/patch0/common/index.ts
@@ -1,0 +1,3 @@
+export function common() {
+  return 35;
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/patch1/utils/index.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/patch1/utils/index.ts
@@ -1,0 +1,5 @@
+import { common } from "../common";
+export function utils() {
+  common();
+}
+export function utils2() { return "hello"; }

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/patch2/app/app.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/patch2/app/app.ts
@@ -1,0 +1,6 @@
+import { lib } from '../lib';
+import { utils, utils2 } from "../utils";
+
+console.log(lib.one, lib.two, lib.three);
+utils();
+utils2();

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/patch3/common/index.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/patch3/common/index.ts
@@ -1,0 +1,3 @@
+export function common(): string {
+  return 35;
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/patch4/common/index.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/patch4/common/index.ts
@@ -1,0 +1,3 @@
+export function common() {
+  return 35;
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/patch5/utils/index.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/patch5/utils/index.ts
@@ -1,0 +1,5 @@
+import { common } from "../common";
+export function utils() {
+  common();
+}
+export function utils2(): number { return "hello"; }

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/patch6/utils/index.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/patch6/utils/index.ts
@@ -1,0 +1,5 @@
+import { common } from "../common";
+export function utils() {
+  common();
+}
+export function utils2() { return "hello"; }

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/utils/index.ts
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/utils/index.ts
@@ -1,0 +1,4 @@
+import { common } from "../common";
+export function utils() {
+  common();
+}

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/utils/tsconfig.json
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/utils/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "types": []
+  },
+  "references": [
+    { "path": "../common" },
+    { "path": "../indirect" }
+  ]
+}


### PR DESCRIPTION
I am not sure if this right change or not as i dont understand much about config and need for different instances but this came up as part of investigation where multiple instances of solution builder were created because different instances were used. The project in question takes about 2-3 minutes to just check if the solution is upto date adding to perf and memory implications.

I am not sure if we need this PR or people just fix their config file to use same instance instead. (which is what investigation resulted in)