### PR TITLE
Add ignoreEmptyOutput config flag for js-only projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,14 @@ loading only those files that are actually bundled by webpack, as well as any `.
 by the `tsconfig.json` settings. `.d.ts` files are still included because they may be needed for
 compilation without being explicitly imported, and therefore not picked up by webpack.
 
+#### ignoreEmptyOutput
+| Type | Default Value |
+|------|--------------|
+| `boolean` | `false`|
+
+Ignore empty tsc output. Is only useful when typechecking pure js projects with the checkJs and
+allowJs options.
+
 #### allowTsInNodeModules
 | Type | Default Value |
 |------|--------------|

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,10 @@ function makeSourceMapAndFinish(
         'See: https://github.com/Microsoft/TypeScript/issues/12358'
       : '';
 
+    if (instance.loaderOptions.ignoreEmptyOutput) {
+      callback(null, contents);
+      return;
+    }
     callback(
       new Error(
         `TypeScript emitted no output for ${filePath}.${additionalGuidance}`
@@ -227,6 +231,7 @@ const validLoaderOptions: ValidLoaderOptions[] = [
   'appendTsSuffixTo',
   'appendTsxSuffixTo',
   'onlyCompileBundledFiles',
+  'ignoreEmptyOutput',
   'happyPackMode',
   'getCustomTransformers',
   'reportFiles',
@@ -287,6 +292,7 @@ function makeLoaderOptions(instanceName: string, loaderOptions: LoaderOptions) {
       happyPackMode: false,
       colors: true,
       onlyCompileBundledFiles: false,
+      ignoreEmptyOutput: false,
       reportFiles: [],
       // When the watch API usage stabilises look to remove this option and make watch usage the default behaviour when available
       experimentalWatchApi: false,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -264,6 +264,7 @@ export interface LoaderOptions {
   reportFiles: string[];
   errorFormatter: (message: ErrorInfo, colors: Chalk) => string;
   onlyCompileBundledFiles: boolean;
+  ignoreEmptyOutput: boolean;
   colors: boolean;
   compilerOptions: typescript.CompilerOptions;
   appendTsSuffixTo: (RegExp | string)[];


### PR DESCRIPTION
I'd like to add a config flag to allow empty output to allow using ts-loader with the noEmit option. This is because I use ts-loader in a js-only project where it is used to add typechecking via the checkJs and allowJs flags in combination with type info in jsdoc. Even though ts-loader in this setup effectively does nothing I like having the typechecking within the webpack pipeline.

If the proposed ignoreEmptyOutput is true then the callback is simply passed the input instead of calculating the output.

Please let me know if there are other/better ways to achive this!