### PR TITLE
Add emit only option

### DIFF
--- a/src/after-compile.ts
+++ b/src/after-compile.ts
@@ -19,6 +19,7 @@ import {
   isReferencedFile,
   populateReverseDependencyGraph,
   tsLoaderSource,
+  fileMatchesPatterns,
 } from './utils';
 
 export function makeAfterCompile(
@@ -39,6 +40,16 @@ export function makeAfterCompile(
     }
 
     if (instance.loaderOptions.transpileOnly) {
+      const { files, loaderOptions } = instance;
+
+      if (loaderOptions.emitOnly.length > 0) {
+        files.forEach((_, key) => {
+          if (fileMatchesPatterns(loaderOptions.emitOnly, key)) {
+            files.delete(key);
+          }
+        });
+      }
+
       provideAssetsFromSolutionBuilderHost(instance, compilation);
       callback();
       return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
 import {
   appendSuffixesIfMatch,
   arrify,
+  fileMatchesPatterns,
   formatErrors,
   isReferencedFile,
 } from './utils';
@@ -76,9 +77,16 @@ function successLoader(
     contents,
     instance
   );
-  const { outputText, sourceMapText } = instance.loaderOptions.transpileOnly
-    ? getTranspilationEmit(filePath, contents, instance, loaderContext)
-    : getEmit(rawFilePath, filePath, instance, loaderContext);
+
+  const noEmit = !fileMatchesPatterns(
+    instance.loaderOptions.emitOnly,
+    filePath
+  );
+
+  const { outputText, sourceMapText } =
+    instance.loaderOptions.transpileOnly || noEmit
+      ? getTranspilationEmit(filePath, contents, instance, loaderContext)
+      : getEmit(rawFilePath, filePath, instance, loaderContext);
 
   makeSourceMapAndFinish(
     sourceMapText,
@@ -220,6 +228,7 @@ const validLoaderOptions: ValidLoaderOptions[] = [
   'context',
   'configFile',
   'transpileOnly',
+  'emitOnly',
   'ignoreDiagnostics',
   'errorFormatter',
   'colors',
@@ -280,6 +289,7 @@ function makeLoaderOptions(instanceName: string, loaderOptions: LoaderOptions) {
       configFile: 'tsconfig.json',
       context: undefined,
       transpileOnly: false,
+      emitOnly: [],
       compilerOptions: {},
       appendTsSuffixTo: [],
       appendTsxSuffixTo: [],

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -254,6 +254,7 @@ export interface LoaderOptions {
   configFile: string;
   context: string;
   transpileOnly: boolean;
+  emitOnly: RegExp[];
   ignoreDiagnostics: number[];
   reportFiles: string[];
   errorFormatter: (message: ErrorInfo, colors: Chalk) => string;

--- a/src/servicesHost.ts
+++ b/src/servicesHost.ts
@@ -28,6 +28,7 @@ import {
 import { makeResolver } from './resolver';
 import {
   ensureTrailingDirectorySeparator,
+  fileMatchesPatterns,
   formatErrors,
   fsReadFile,
   populateDependencyGraph,
@@ -98,6 +99,15 @@ function makeResolversHandlingProjectReferences(
   );
 
   function fileExists(filePathToCheck: string) {
+    const shouldEmit = fileMatchesPatterns(
+      instance.loaderOptions.emitOnly,
+      filePathToCheck
+    );
+
+    if (!shouldEmit) {
+      return false;
+    }
+
     const outputFile = instance.solutionBuilderHost?.getOutputFileFromReferencedProject(
       filePathToCheck
     );
@@ -197,6 +207,14 @@ export function makeServicesHost(
       fsReadFile(filePathToCheck) !== undefined,
     instance.loaderOptions.experimentalFileCaching
   );
+
+  if (instance.loaderOptions.emitOnly.length > 0) {
+    files.forEach((_value, key) => {
+      if (!fileMatchesPatterns(instance.loaderOptions.emitOnly, key)) {
+        files.delete(key);
+      }
+    });
+  }
 
   const servicesHost: ServiceHostWhichMayBeCacheable = {
     getProjectVersion: () => `${instance.version}`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -311,3 +311,7 @@ export function useCaseSensitiveFileNames(
     ? loaderOptions.useCaseSensitiveFileNames
     : compiler.sys.useCaseSensitiveFileNames;
 }
+
+export function fileMatchesPatterns(patterns: RegExp[], file: string): boolean {
+  return patterns.some(regexp => file.match(regexp) != null);
+}


### PR DESCRIPTION
Emit specific declarations with the transpileOnly flag. Libraries like Typeorm require certain declarations for type inference at runtime.


Closes #1100