### PR TITLE
Replace afterCompile to stop webpack 5 warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v8.0.6
+* [Fixed further deprecation warning on webpack@5](https://github.com/TypeStrong/ts-loader/issues/1196) - thanks @appzuka
+
 ## v8.0.5
 * [Fixed deprecation warnings on webpack@5](https://github.com/TypeStrong/ts-loader/issues/1194) - thanks @sanex3339
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.0.5",
+  "version": "8.0.6",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -341,10 +341,26 @@ export function initializeInstance(
     instance.transformers = getCustomTransformers(program);
     // Setup watch run for solution building
     if (instance.solutionBuilderHost) {
-      loader._compiler.hooks.afterCompile.tapAsync(
-        'ts-loader',
-        makeAfterCompile(instance, instance.configFilePath)
-      );
+      if (loader._compilation.hooks.afterProcessAssets) {
+        // afterProcessAssets does not exist in webpack4
+        loader._compilation.hooks.afterProcessAssets.tap(
+          'ts-loader',
+          (_: any) => {
+            makeAfterCompile(instance, instance.configFilePath)(
+              loader._compilation,
+              () => {
+                return null;
+              }
+            );
+          }
+        );
+      } else {
+        // adding assets in afterCompile is depracated in webpack 5
+        loader._compiler.hooks.afterCompile.tapAsync(
+          'ts-loader',
+          makeAfterCompile(instance, instance.configFilePath)
+        );
+      }
       loader._compiler.hooks.watchRun.tapAsync(
         'ts-loader',
         makeWatchRun(instance, loader)
@@ -391,11 +407,27 @@ export function initializeInstance(
         instance.languageService!.getProgram()
       );
     }
+    if (loader._compilation.hooks.afterProcessAssets) {
+      // afterProcessAssets does not exist in webpack4
+      loader._compilation.hooks.afterProcessAssets.tap(
+        'ts-loader',
+        (_: any) => {
+          makeAfterCompile(instance, instance.configFilePath)(
+            loader._compilation,
+            () => {
+              return null;
+            }
+          );
+        }
+      );
+    } else {
+      // adding assets in afterCompile is depracated in webpack 5
+      loader._compiler.hooks.afterCompile.tapAsync(
+        'ts-loader',
+        makeAfterCompile(instance, instance.configFilePath)
+      );
+    }
 
-    loader._compiler.hooks.afterCompile.tapAsync(
-      'ts-loader',
-      makeAfterCompile(instance, instance.configFilePath)
-    );
     loader._compiler.hooks.watchRun.tapAsync(
       'ts-loader',
       makeWatchRun(instance, loader)

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -355,7 +355,7 @@ export function initializeInstance(
           }
         );
       } else {
-        // adding assets in afterCompile is depracated in webpack 5
+        // adding assets in afterCompile is deprecated in webpack 5
         loader._compiler.hooks.afterCompile.tapAsync(
           'ts-loader',
           makeAfterCompile(instance, instance.configFilePath)
@@ -421,7 +421,7 @@ export function initializeInstance(
         }
       );
     } else {
-      // adding assets in afterCompile is depracated in webpack 5
+      // adding assets in afterCompile is deprecated in webpack 5
       loader._compiler.hooks.afterCompile.tapAsync(
         'ts-loader',
         makeAfterCompile(instance, instance.configFilePath)


### PR DESCRIPTION
This fixes the deprecation warning in webpack 5 as discussed in issue #[1196](https://github.com/TypeStrong/ts-loader/issues/1196). Writing assets such as declarations is moved to the afterProcessAssets hook of the compilation from the afterCompile hook of the compiler.

As the afterProcessAssets hook does not exist in webpack 4 to make ts-loader work for both webpack 4 and 5 it is necessary to execute different code depending on whether afterProcessAssets exists.  This means that the new code is not tested at all by either the execution or comparison tests, which feels wrong.  I'm not sure how to fix this until tests using webpack 5 are introduced, which feels like a major task.

I have tested this build with a small project using webpack 4 and webpack 5.  If I introduce a deliberate error into the webpack 5 branch of the new code all the tests still pass although building the project with webpack 5 fails.