### PR TITLE
doc: escape pipe in table

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,12 +496,12 @@ of your code.
 #### appendTsSuffixTo
 | Type | Default Value |
 |------|--------------|
-| `(RegExp | string)[]` | `[]`|
+| `(RegExp \| string)[]` | `[]`|
 
 #### appendTsxSuffixTo
 | Type | Default Value |
 |------|--------------|
-| `(RegExp | string)[]` | `[]`|
+| `(RegExp \| string)[]` | `[]`|
 
 A list of regular expressions to be matched against filename. If filename matches one of the regular expressions, a `.ts` or `.tsx` suffix will be appended to that filename.
 If you're using [HappyPack](https://github.com/amireh/happypack) or [thread-loader](https://github.com/webpack-contrib/thread-loader) with `ts-loader`, you need use the `string` type for the regular expressions, not `RegExp` object.


### PR DESCRIPTION
This fixes broken tables.

before
![image](https://user-images.githubusercontent.com/39250601/96824761-90998080-146a-11eb-9358-d87f657b2985.png)

after
![image](https://user-images.githubusercontent.com/39250601/96824781-9abb7f00-146a-11eb-8d2c-a78b31b87134.png)
