### PR TITLE
Fix memory leak when using multiple webpack instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v8.0.8
+* [Fixed memory leak when using multiple webpack instances](https://github.com/TypeStrong/ts-loader/pull/1205) - thanks @valerio
+
 ## v8.0.7
 * [Speeds up project reference build and doesnt store the result in memory](https://github.com/TypeStrong/ts-loader/pull/1202) - thanks @sheetalkamat
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.0.7",
+  "version": "8.0.8",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -33,7 +33,7 @@ import {
 } from './utils';
 import { makeWatchRun } from './watch-run';
 
-const instances = new Map<string, TSInstance>();
+const instances = new WeakMap<LoaderOptions, TSInstance>();
 const instancesBySolutionBuilderConfigs = new Map<FilePathKey, TSInstance>();
 
 /**
@@ -47,7 +47,7 @@ export function getTypeScriptInstance(
   loaderOptions: LoaderOptions,
   loader: webpack.loader.LoaderContext
 ): { instance?: TSInstance; error?: WebpackError } {
-  const existing = instances.get(loaderOptions.instance);
+  const existing = instances.get(loaderOptions);
   if (existing) {
     if (!existing.initialSetupPending) {
       ensureProgram(existing);
@@ -141,7 +141,7 @@ function successfulTypeScriptInstance(
     const existing = getExistingSolutionBuilderHost(configFileKey);
     if (existing) {
       // Reuse the instance if config file for project references is shared.
-      instances.set(loaderOptions.instance, existing);
+      instances.set(loaderOptions, existing);
       return { instance: existing };
     }
   }
@@ -226,7 +226,8 @@ function successfulTypeScriptInstance(
       log,
       filePathKeyMapper,
     };
-    instances.set(loaderOptions.instance, transpileInstance);
+
+    instances.set(loaderOptions, transpileInstance);
     return { instance: transpileInstance };
   }
 
@@ -278,7 +279,7 @@ function successfulTypeScriptInstance(
     log,
     filePathKeyMapper,
   };
-  instances.set(loaderOptions.instance, instance);
+  instances.set(loaderOptions, instance);
   return { instance };
 }
 


### PR DESCRIPTION
Closes https://github.com/TypeStrong/ts-loader/issues/1203

This PR should fix a memory leak issue when using multiple webpack instances that get discarded over time.

I initially converted the `webpackInstances` array to a WeakMap (plus a global index) but that wasn't enough to fix the leak, since the cached `TSInstance` held in `instances.ts` was still retaining the webpack compiler and never being freed.

In the end, I removed the webpack instance array and changed the TS instance cache by using a combined WeakMap + Map so that we maintain the same behaviour but keep the lifetime of `TSInstance`s tied to the webpack compiler that spawned them.

There is one small change in how `loaderOptions.instance` names are generated: 
- old names: `0_default_e3b0c44298fc1c14`
- new names: `default_e3b0c44298fc1c14`

They now don't contain the unique index for the webpack compiler that generated them, this shouldn't change the way instances are cached, since they are now tied to a specific webpack instance by reference (the key of the WeakMap) instead of using the index.

I've tested that the leak is fixed using this repo: https://github.com/valerio/ts-loader-leak
Memory now gets periodically freed between runs:
```
➜  ts-loader-leak git:(main) node index.js 1
webpack will run, process should run out of memory
current heap usage { heapMBs: 101 }
current heap usage { heapMBs: 151 }
// omitted for brevity
current heap usage { heapMBs: 882 }
current heap usage { heapMBs: 937 }
current heap usage { heapMBs: 991 }
current heap usage { heapMBs: 98 } <-- memory was freed 
current heap usage { heapMBs: 154 }
current heap usage { heapMBs: 208 }
current heap usage { heapMBs: 257 }
current heap usage { heapMBs: 312 }
current heap usage { heapMBs: 366 }
current heap usage { heapMBs: 155 } <-- memory was freed 
current heap usage { heapMBs: 202 }
current heap usage { heapMBs: 257 }
current heap usage { heapMBs: 312 }
current heap usage { heapMBs: 359 }
```

I thought about adding a test case in here but I don't think it would fit with the current setup, it also might be non-deterministic.