### PR TITLE
Fix failed builds when using thread-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v8.0.9
+* [Fixed build failing when using thread-loader](https://github.com/TypeStrong/ts-loader/pull/1207) - thanks @valerio
+
 ## v8.0.8
 * [Fixed memory leak when using multiple webpack instances](https://github.com/TypeStrong/ts-loader/pull/1205) - thanks @valerio
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.0.8",
+  "version": "8.0.9",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/instance-cache.ts
+++ b/src/instance-cache.ts
@@ -1,0 +1,39 @@
+import * as webpack from 'webpack';
+import { TSInstance } from './interfaces';
+
+// Some loaders (e.g. thread-loader) will set the _compiler property to undefined.
+// We can't use undefined as a WeakMap key as it will throw an error at runtime,
+// thus we keep a dummy "marker" object to use as key in those situations.
+const marker: webpack.Compiler = {} as webpack.Compiler;
+
+// Each TypeScript instance is cached based on the webpack instance (key of the WeakMap)
+// and also the name that was generated or passed via the options (string key of the
+// internal Map)
+const cache: WeakMap<webpack.Compiler, Map<string, TSInstance>> = new WeakMap();
+
+export function getTSInstanceFromCache(
+  key: webpack.Compiler,
+  name: string
+): TSInstance | undefined {
+  const compiler = key ?? marker;
+
+  let instances = cache.get(compiler);
+  if (!instances) {
+    instances = new Map();
+    cache.set(compiler, instances);
+  }
+
+  return instances.get(name);
+}
+
+export function setTSInstanceInCache(
+  key: webpack.Compiler,
+  name: string,
+  instance: TSInstance
+) {
+  const compiler = key ?? marker;
+
+  const instances = cache.get(compiler) ?? new Map<string, TSInstance>();
+  instances.set(name, instance);
+  cache.set(compiler, instances);
+}


### PR DESCRIPTION
Possible fix for https://github.com/TypeStrong/ts-loader/issues/1206

When using `thread-loader`, the `loader._compiler` field is `undefined`, this causes a runtime error when trying to use it as a key in a WeakMap.

This PR changes the instance cache so that it now uses a dummy "marker" object as reference when the compiler instance is undefined.