### PR TITLE
Fixed missing errors in watch mode in webpack5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v8.0.10
+* [Fixed missing errors in watch mode in webpack5](https://github.com/TypeStrong/ts-loader/issues/1204) - thanks @appzuka
+
 ## v8.0.9
 * [Fixed build failing when using thread-loader](https://github.com/TypeStrong/ts-loader/pull/1207) - thanks @valerio
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.0.9",
+  "version": "8.0.10",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -302,46 +302,45 @@ function getExistingSolutionBuilderHost(key: FilePathKey) {
   return undefined;
 }
 
-const addAssetHooks = (
-  loader: webpack.loader.LoaderContext,
-  instance: TSInstance
-) => {
-  // Adding assets in afterCompile is deprecated in webpack 5 so we
-  // need different behavior for webpack4 and 5
+// Adding assets in afterCompile is deprecated in webpack 5 so we
+// need different behavior for webpack4 and 5
+const addAssetHooks = !!webpack.version!.match(/^4.*/)
+  ? (loader: webpack.loader.LoaderContext, instance: TSInstance) => {
+      // add makeAfterCompile with addAssets = true to emit assets and report errors
+      loader._compiler.hooks.afterCompile.tapAsync(
+        'ts-loader',
+        makeAfterCompile(instance, true, true, instance.configFilePath)
+      );
+    }
+  : (loader: webpack.loader.LoaderContext, instance: TSInstance) => {
+      // We must be running under webpack 5+
 
-  if (!!webpack.version!.match(/^4.*/)) {
-    // add makeAfterCompile with addAssets = true to emit assets and report errors
-    loader._compiler.hooks.afterCompile.tapAsync(
-      'ts-loader',
-      makeAfterCompile(instance, true, true, instance.configFilePath)
-    );
-    return;
-  }
-  // We must be running under webpack 5+
+      // Add makeAfterCompile with addAssets = false to suppress emitting assets
+      // during the afterCompile stage. Errors will be still be reported to webpack
+      loader._compiler.hooks.afterCompile.tapAsync(
+        'ts-loader',
+        makeAfterCompile(instance, false, true, instance.configFilePath)
+      );
 
-  // Add makeAfterCompile with addAssets = false to suppress emitting assets
-  // during the afterCompile stage. Errors will be still be reported to webpack
-  loader._compiler.hooks.afterCompile.tapAsync(
-    'ts-loader',
-    makeAfterCompile(instance, false, true, instance.configFilePath)
-  );
+      // Emit the assets at the afterProcessAssets stage
+      loader._compilation.hooks.afterProcessAssets.tap(
+        'ts-loader',
+        (_: any) => {
+          makeAfterCompile(
+            instance,
+            true,
+            false,
+            instance.configFilePath
+          )(loader._compilation, () => {
+            return null;
+          });
+        }
+      );
 
-  // Emit the assets at the afterProcessAssets stage
-  loader._compilation.hooks.afterProcessAssets.tap('ts-loader', (_: any) => {
-    makeAfterCompile(
-      instance,
-      true,
-      false,
-      instance.configFilePath
-    )(loader._compilation, () => {
-      return null;
-    });
-  });
-
-  // It may be better to add assets at the processAssets stage (https://webpack.js.org/api/compilation-hooks/#processassets)
-  // This requires Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL, which does not exist in webpack4
-  // Consider changing this when ts-loader is built using webpack5
-};
+      // It may be better to add assets at the processAssets stage (https://webpack.js.org/api/compilation-hooks/#processassets)
+      // This requires Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL, which does not exist in webpack4
+      // Consider changing this when ts-loader is built using webpack5
+    };
 
 export function initializeInstance(
   loader: webpack.loader.LoaderContext,


### PR DESCRIPTION
The fix in [PR1200](https://github.com/TypeStrong/ts-loader/pull/1200) was made to prevent deprecation warnings with webpack5, because it is no longer allowed to add assets during the afterCompile hook.  These functions were moved to the new afterProcessAssets hook in webpack5.  It seems that in watch mode, the afterProcessAssets hook is not called, so if any errors are introduced they will not be reported to webpack.

This PR allows the makeAfterCompile function to select whether assets should be added and/or errors should be reported.  Running under webpack4 the behaviour is unchanged.  Under webpack5 assets are added during afterProcessAssets and errors are reported during afterCompile.  This should correct the behaviour observed in [#1204](https://github.com/TypeStrong/ts-loader/issues/1204).

This PR passes all comparison and execution tests, but as these run under webpack4 the webpack5 behaviour is not tested.  I assume this will be corrected in the future when webpack5 is used to build ts-loader.