### PR TITLE
Add peer dependencies for Yarn PnP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v8.0.11
+* [Fixed build failing in yarn v2 pnp](https://github.com/TypeStrong/ts-loader/pull/1209) - @aicest
+
 ## v8.0.10
 * [Fixed missing errors in watch mode in webpack5](https://github.com/TypeStrong/ts-loader/issues/1204) - thanks @appzuka
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.0.10",
+  "version": "8.0.11",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",
@@ -101,6 +101,7 @@
     "webpack-cli": "^3.1.1"
   },
   "peerDependencies": {
-    "typescript": "*"
+    "typescript": "*",
+    "webpack": "*"
   }
 }


### PR DESCRIPTION
Desc: should explicitly indicate peer/optional dependency for yarn v2.

Reproducing bug: https://github.com/aicest/webpack-v5-demo

<img width="767" alt="捕获" src="https://user-images.githubusercontent.com/4016742/98458043-8b0c9c00-21c7-11eb-92f8-088b40299d93.PNG">

