### PR TITLE
Instead of checking date, check time thats more accurate to see if something has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## v8.0.12
+* [Instead of checking date, check time thats more accurate to see if something has changed](https://github.com/TypeStrong/ts-loader/pull/1217) - thanks @sheetalkamat
+
 ## v8.0.11
-* [Fixed build failing in yarn v2 pnp](https://github.com/TypeStrong/ts-loader/pull/1209) - @aicest
+* [Fixed build failing in yarn v2 pnp](https://github.com/TypeStrong/ts-loader/pull/1209) - thanks @aicest
 
 ## v8.0.10
 * [Fixed missing errors in watch mode in webpack5](https://github.com/TypeStrong/ts-loader/issues/1204) - thanks @appzuka

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.0.11",
+  "version": "8.0.12",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/servicesHost.ts
+++ b/src/servicesHost.ts
@@ -1040,7 +1040,7 @@ export function makeSolutionBuilderHost(
     const existing = inputFiles.get(key) || missingFileModifiedTime;
     const newTime =
       compiler.sys.getModifiedTime!(fileName) || missingFileModifiedTime;
-    if (existing === newTime) {
+    if (existing.getTime() === newTime.getTime()) {
       return;
     }
     const eventKind =


### PR DESCRIPTION
This ensures that there is no unnecesary watcher invoked resulting in full config file reloads and builds