### PR TITLE
Remove @types/webpack due to Webpack 5 update

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@types/micromatch": "^3.1.0",
     "@types/node": "*",
     "@types/semver": "^6.0.0",
-    "@types/webpack": "^4.4.30",
     "@typescript-eslint/eslint-plugin": "^4.0.0",
     "@typescript-eslint/parser": "^4.0.0",
     "babel": "^6.0.0",


### PR DESCRIPTION
According to the [update notes](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#typescript-typings), the package `@types/webpack` is no longer used. It should be removed from `package.json`.