### PR TITLE
Increase build performance by skipping node_modules file lookups

### DIFF
--- a/src/servicesHost.ts
+++ b/src/servicesHost.ts
@@ -852,6 +852,14 @@ export function makeSolutionBuilderHost(
   function getInputFileNameFromOutput(
     outputFileName: string
   ): string | true | undefined {
+    // Unless we explicitly want to compile files in node_modules, exclude them from lookups
+    if (
+      !instance.loaderOptions.allowTsInNodeModules &&
+      outputFileName.indexOf('node_modules') !== -1
+    ) {
+      return undefined;
+    }
+
     const resolvedFileName = filePathKeyMapper(outputFileName);
     for (const configInfo of configFileInfo.values()) {
       ensureInputOutputInfo(configInfo);

--- a/src/servicesHost.ts
+++ b/src/servicesHost.ts
@@ -855,7 +855,7 @@ export function makeSolutionBuilderHost(
     // Unless we explicitly want to compile files in node_modules, exclude them from lookups
     if (
       !instance.loaderOptions.allowTsInNodeModules &&
-      outputFileName.indexOf('node_modules') !== -1
+      outputFileName.indexOf('/node_modules/') !== -1
     ) {
       return undefined;
     }


### PR DESCRIPTION
Skip attempting to lookup node_modules output files names inside getInputFileNameFromOutput. This should never resolve if the allowTsInNodeModule loader option is not set.

Tested in a closed-source project & showed a large improvement in speed over 8.0.12 (~20% decrease in build times)

Relates to #1215