### PR TITLE
Add documentation for the useCaseSensitiveFileNames option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
     + [appendTsSuffixTo](#appendtssuffixto)
     + [appendTsxSuffixTo](#appendtsxsuffixto)
     + [onlyCompileBundledFiles](#onlycompilebundledfiles)
+    + [useCaseSensitiveFileNames](#useCaseSensitiveFileNames)
     + [allowTsInNodeModules](#allowtsinnodemodules)
     + [context](#context)
     + [experimentalFileCaching](#experimentalfilecaching)
@@ -624,6 +625,15 @@ any files specified by those options. The `onlyCompileBundledFiles` option modif
 loading only those files that are actually bundled by webpack, as well as any `.d.ts` files included
 by the `tsconfig.json` settings. `.d.ts` files are still included because they may be needed for
 compilation without being explicitly imported, and therefore not picked up by webpack.
+
+#### useCaseSensitiveFileNames
+| Type | Default Value |
+|------|--------------|
+| `boolean` | determined by typescript based on platform |
+
+The default behavior of `ts-loader` is to act as a drop-in replacement for the `tsc` command,
+so it respects the `useCaseSensitiveFileNames` set internally by typescript. The `useCaseSensitiveFileNames` option modifies this behavior,
+by changing the way in which ts-loader resolves file paths to compile. Setting this to true can have some performance benefits due to simplifying the file resolution codepath.
 
 #### allowTsInNodeModules
 | Type | Default Value |


### PR DESCRIPTION
Setting this option on projects with lots of files can reduce compilation time. Case-insensitivty requires normalization of file paths, which involves executing regex's. This shows up in the hot path of compilation profiling.
Switching to case sensitive file names skips the normalization step and increases build speed by ~5%  (closed-source project, sorry)