### PR TITLE
Add a cache to file path mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## v8.0.13
+* [Speed up builds by adding an in-memory cache to file path lookups](https://github.com/TypeStrong/ts-loader/pull/1228) - thanks @berickson1
 
 ## v8.0.12
 * [Instead of checking date, check time thats more accurate to see if something has changed](https://github.com/TypeStrong/ts-loader/pull/1217) - thanks @sheetalkamat

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.0.12",
+  "version": "8.0.13",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -95,25 +95,25 @@ function createFilePathKeyMapper(
     ? pathResolve
     : toFileNameLowerCase;
 
-  function pathResolve(x: string) {
-    let cachedPath = filePathMapperCache.get(x);
+  function pathResolve(filePath: string) {
+    let cachedPath = filePathMapperCache.get(filePath);
     if (!cachedPath) {
-      cachedPath = path.resolve(x) as FilePathKey;
-      filePathMapperCache.set(x, cachedPath);
+      cachedPath = path.resolve(filePath) as FilePathKey;
+      filePathMapperCache.set(filePath, cachedPath);
     }
     return cachedPath;
   }
 
-  function toFileNameLowerCase(x: string) {
-    let cachedPath = filePathMapperCache.get(x);
+  function toFileNameLowerCase(filePath: string) {
+    let cachedPath = filePathMapperCache.get(filePath);
     if (!cachedPath) {
-      const filePathKey = pathResolve(x);
+      const filePathKey = pathResolve(filePath);
       cachedPath = fileNameLowerCaseRegExp.test(filePathKey)
         ? (filePathKey.replace(fileNameLowerCaseRegExp, ch =>
             ch.toLowerCase()
           ) as FilePathKey)
         : filePathKey;
-      filePathMapperCache.set(x, cachedPath);
+      filePathMapperCache.set(filePath, cachedPath);
     }
     return cachedPath;
   }


### PR DESCRIPTION
This greatly reduces the time needed to resolve FilePathKey objects on watch builds. (~20% from 20s to 16s)

Note: The only case where I could see this optimization performing poorly is if a symlink was changed between builds, but I don't believe webpack handles that gracefully anyways.

Relates to #1215

See the performance traces below:

Before:
<img width="874" alt="Screen Shot 2020-12-29 at 1 25 50 PM" src="https://user-images.githubusercontent.com/1418465/103320390-003b6700-49ea-11eb-83af-87e61b613a5e.png">
<img width="841" alt="Screen Shot 2020-12-29 at 1 26 01 PM" src="https://user-images.githubusercontent.com/1418465/103320394-03365780-49ea-11eb-94a2-1863837d2bc1.png">

After:
<img width="958" alt="Screen Shot 2020-12-29 at 1 35 58 PM" src="https://user-images.githubusercontent.com/1418465/103320404-0d585600-49ea-11eb-8279-bda8705b95ff.png">
<img width="668" alt="Screen Shot 2020-12-29 at 1 36 14 PM" src="https://user-images.githubusercontent.com/1418465/103320401-0af5fc00-49ea-11eb-87e1-2e7e4b3a9f11.png">
