### PR TITLE
Minor improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.0.15",
+  "version": "9.0.0",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",
@@ -96,7 +96,7 @@
     "rimraf": "^2.6.2",
     "typescript": "^4.0.0",
     "webpack": "^5.20.0",
-    "webpack-cli": "^3.1.1"
+    "webpack-cli": "^4.5.0"
   },
   "peerDependencies": {
     "typescript": "*",

--- a/src/after-compile.ts
+++ b/src/after-compile.ts
@@ -135,7 +135,7 @@ function determineModules(
   const modules: Map<FilePathKey, webpack.Module[]> = new Map();
 
   compilation.modules.forEach(module => {
-    if (module.resource) {
+    if (module instanceof webpack.NormalModule && module.resource) {
       const modulePath = filePathKeyMapper(module.resource);
       const existingModules = modules.get(modulePath);
       if (existingModules !== undefined) {
@@ -399,10 +399,8 @@ function outputFileToAsset(
     compilation.compiler.outputPath,
     outputFile.name
   );
-  compilation.assets[assetPath] = {
-    source: () => outputFile.text,
-    size: () => outputFile.text.length,
-  };
+
+  compilation.emitAsset(assetPath, new webpack.sources.RawSource(outputFile.text));
 }
 
 function outputFilesToAsset<T extends ts.OutputFile>(

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -343,11 +343,11 @@ const addAssetHooks = !!webpack.version!.match(/^4.*/)
       // compilation is actually of type webpack.Compilation, but afterProcessAssets
       // only exists in webpack5 and at the time of writing ts-loader is built using webpack4
       const makeAssetsCallback = (compilation: any) => {
-        compilation.hooks.afterProcessAssets.tap('ts-loader', () =>
+        compilation.hooks.processAssets.tap({ name: 'ts-loader', stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL }, (_assets: webpack.Asset[]) => {
           cachedMakeAfterCompile(compilation, () => {
             return null;
-          })
-        );
+          });
+        });
       };
 
       // We need to add the hook above for each run.


### PR DESCRIPTION
Updated webpack-cli
Added types for Webpack (Do we want this?)
Added skipLibCheck to supress errors caused by webpack dependencies (needed for now due to https://github.com/webpack/webpack/issues/12185, not sure if we should verify external packages typings though?)
Implemented compilation.emitAssets for additional resources
Replaced afterProcessAssets with processAssets hook