### PR TITLE
Re-fix Webpack 5 watch not failing on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## v8.0.15
+* [Update definition files in watch mode in webpack@5](https://github.com/TypeStrong/ts-loader/pull/1249) - thanks @appzuka,@JonWallsten,@alexander-akait
+* [Add afterDeclarations to getCustomTransformers in README.md](https://github.com/TypeStrong/ts-loader/pull/1248) - thanks @appzuka
+
 ## v8.0.14
 * [Upgrade `chalk`, `loader-utils`, and `semver` to latest stable versions](https://github.com/TypeStrong/ts-loader/pull/1237) - thanks Avi Vahl
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v8.0.16
+* [Re-Fixed missing errors in watch mode in webpack5](https://github.com/TypeStrong/ts-loader/issues/1204) - thanks @appzuka
+
 ## v8.0.15
 * [Update definition files in watch mode in webpack@5](https://github.com/TypeStrong/ts-loader/pull/1249) - thanks @appzuka,@JonWallsten,@alexander-akait
 * [Add afterDeclarations to getCustomTransformers in README.md](https://github.com/TypeStrong/ts-loader/pull/1248) - thanks @appzuka

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ These options should be functions which will be used to resolve the import state
 #### getCustomTransformers
 | Type |
 |------|
-| ` (program: Program) => { before?: TransformerFactory<SourceFile>[]; after?: TransformerFactory<SourceFile>[]; } ` |
+| ` (program: Program) => { before?: TransformerFactory<SourceFile>[]; after?: TransformerFactory<SourceFile>[]; afterDeclarations?: TransformerFactory<SourceFile>[]; } ` |
 
 Provide custom transformers - only compatible with TypeScript 2.3+ (and 2.4 if using `transpileOnly` mode). For example usage take a look at [typescript-plugin-styled-components](https://github.com/Igorbek/typescript-plugin-styled-components) or our [test](test/comparison-tests/customTransformer).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.0.15",
+  "version": "8.0.16",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.0.14",
+  "version": "8.0.15",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/after-compile.ts
+++ b/src/after-compile.ts
@@ -29,8 +29,6 @@ import {
  */
 export function makeAfterCompile(
   instance: TSInstance,
-  addAssets: boolean,
-  provideErrors: boolean,
   configFilePath: string | undefined
 ) {
   let getCompilerOptionDiagnostics = true;
@@ -47,22 +45,18 @@ export function makeAfterCompile(
     }
 
     if (instance.loaderOptions.transpileOnly) {
-      if (addAssets) {
-        provideAssetsFromSolutionBuilderHost(instance, compilation);
-      }
+      provideAssetsFromSolutionBuilderHost(instance, compilation);
       callback();
       return;
     }
     removeCompilationTSLoaderErrors(compilation, instance.loaderOptions);
 
-    if (provideErrors) {
-      provideCompilerOptionDiagnosticErrorsToWebpack(
-        getCompilerOptionDiagnostics,
-        compilation,
-        instance,
-        configFilePath
-      );
-    }
+    provideCompilerOptionDiagnosticErrorsToWebpack(
+      getCompilerOptionDiagnostics,
+      compilation,
+      instance,
+      configFilePath
+    );
     getCompilerOptionDiagnostics = false;
 
     const modules = determineModules(compilation, instance);
@@ -74,25 +68,21 @@ export function makeAfterCompile(
     checkAllFilesForErrors = false;
 
     const filesWithErrors: TSFiles = new Map();
-    if (provideErrors) {
-      provideErrorsToWebpack(
-        filesToCheckForErrors,
-        filesWithErrors,
-        compilation,
-        modules,
-        instance
-      );
-      provideSolutionErrorsToWebpack(compilation, modules, instance);
-    }
-    if (addAssets) {
-      provideDeclarationFilesToWebpack(
-        filesToCheckForErrors,
-        instance,
-        compilation
-      );
-      provideTsBuildInfoFilesToWebpack(instance, compilation);
-      provideAssetsFromSolutionBuilderHost(instance, compilation);
-    }
+    provideErrorsToWebpack(
+      filesToCheckForErrors,
+      filesWithErrors,
+      compilation,
+      modules,
+      instance
+    );
+    provideSolutionErrorsToWebpack(compilation, modules, instance);
+    provideDeclarationFilesToWebpack(
+      filesToCheckForErrors,
+      instance,
+      compilation
+    );
+    provideTsBuildInfoFilesToWebpack(instance, compilation);
+    provideAssetsFromSolutionBuilderHost(instance, compilation);
 
     instance.filesWithErrors = filesWithErrors;
     instance.modifiedFiles = undefined;

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -354,23 +354,6 @@ const addAssetHooks = !!webpack.version!.match(/^4.*/)
       // For future calls in watch mode we need to watch for a new compilation and add the hook
       loader._compiler.hooks.compilation.tap('ts-loader', makeAssetsCallback);
 
-      // compilation is actually of type webpack.compilation.Compilation, but afterProcessAssets
-      // only exists in webpack5 and at the time of writing ts-loader is built using webpack4
-      const makeAssetsCallback = (compilation: any) => {
-        compilation.hooks.afterProcessAssets.tap('ts-loader', () =>
-          cachedMakeAfterCompile(compilation, () => {
-            return null;
-          })
-        );
-      };
-
-      // We need to add the hook above for each run.
-      // For the first run, we just need to add the hook to loader._compilation
-      makeAssetsCallback(loader._compilation);
-
-      // For future calls in watch mode we need to watch for a new compilation and add the hook
-      loader._compiler.hooks.compilation.tap('ts-loader', makeAssetsCallback);
-
       // It may be better to add assets at the processAssets stage (https://webpack.js.org/api/compilation-hooks/#processassets)
       // This requires Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL, which does not exist in webpack4
       // Consider changing this when ts-loader is built using webpack5

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -323,26 +323,17 @@ const addAssetHooks = !!webpack.version!.match(/^4.*/)
       // add makeAfterCompile with addAssets = true to emit assets and report errors
       loader._compiler.hooks.afterCompile.tapAsync(
         'ts-loader',
-        makeAfterCompile(instance, true, true, instance.configFilePath)
+        makeAfterCompile(instance, instance.configFilePath)
       );
     }
   : (loader: webpack.loader.LoaderContext, instance: TSInstance) => {
       // We must be running under webpack 5+
-
-      // Add makeAfterCompile with addAssets = false to suppress emitting assets
-      // during the afterCompile stage. Errors will be still be reported to webpack
-      loader._compiler.hooks.afterCompile.tapAsync(
-        'ts-loader',
-        makeAfterCompile(instance, false, true, instance.configFilePath)
-      );
 
       // makeAfterCompile is a closure.  It returns a function which closes over the variable checkAllFilesForErrors
       // We need to get the function once and then reuse it, otherwise it will be recreated each time
       // and all files will always be checked.
       const cachedMakeAfterCompile = makeAfterCompile(
         instance,
-        true,
-        false,
         instance.configFilePath
       );
 


### PR DESCRIPTION
See: https://github.com/TypeStrong/ts-loader/issues/1204

Originally, declaration file and errors were emitted during the compiler.afterCompile hook. In webpack5 it is no longer allowed to emit assets in the afterCompile hook so I moved this to the compilation.afterProcessAssets hook. But then as reported here errors were not emitted in watch mode. So I made the change here which is to emit errors during the compiler.afterCompile hook but to emit declaration files in the loader._compilation.afterProcessAssets hook.

But then it was reported that declaration files are not emitted in subsequent runs during watch mode. This was traced to loader._compilation not being persistent so we need to use a compilation hook to get the compilation so we can add the afterProcessAssets hook. With hindsight, this was also the cause of errors not being emitted in the previous step and would have been a better solution.

But now I have broken error reporting again. I can see this is because when we emit the declaration files the list of files to check for errors is reset, so when we check whether there are any errors in the afterCompile stage no files are checked.

If I change the code so that errors and declaration files are emitted at the compiler.afterProcessAssets stage everything seems to work correctly for both errors and declaration files for both normal and watch builds. 