### PR TITLE
Include standard webpack start/end locations in emitted errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v8.0.17
+* [Included correct webpack source location in emitted errors](https://github.com/TypeStrong/ts-loader/issues/1199) - thanks @lorenzodallavecchia
+
 ## v8.0.16
 * [Re-Fixed missing errors in watch mode in webpack5](https://github.com/TypeStrong/ts-loader/issues/1204) - thanks @appzuka
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.0.16",
+  "version": "8.0.17",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,12 +13,25 @@ export interface ErrorInfo {
   context: string;
 }
 
-export type FileLocation = { line: number; character: number };
+export type FileLocation = {
+  /** 1-based */
+  line: number;
+  /** 1-based */
+  character: number;
+};
 
+export type WebpackSourcePosition = {
+  /** 1-based */
+  line: number;
+  /** 0-based */
+  column?: number;
+};
 export interface WebpackError {
   module?: any;
   file?: string;
   message: string;
+  loc?: { start: WebpackSourcePosition; end?: WebpackSourcePosition };
+  /* ts-loader extra properties */
   location?: FileLocation;
   loaderSource: string;
 }

--- a/test/comparison-tests/aliasResolution/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/aliasResolution/expectedOutput-4.1/output.txt
@@ -5,6 +5,6 @@ Entrypoint main = bundle.js
 [./common/components/myComponent.ts] 46 bytes {main} [built]
 
 ERROR in app.ts
-./app.ts
+./app.ts 2:30-55
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(2,31)[39m[22m
 [1m[31m      TS2307: Cannot find module 'components/myComponent2' or its corresponding type declarations.[39m[22m

--- a/test/comparison-tests/aliasResolution/expectedOutput-4.1/patch0/output.txt
+++ b/test/comparison-tests/aliasResolution/expectedOutput-4.1/patch0/output.txt
@@ -5,6 +5,6 @@ Entrypoint main = bundle.js
 [./common/components/myComponent.ts] 45 bytes {main} [built]
 
 ERROR in app.ts
-./app.ts
+./app.ts 2:30-55
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(2,31)[39m[22m
 [1m[31m      TS2307: Cannot find module 'components/myComponent2' or its corresponding type declarations.[39m[22m

--- a/test/comparison-tests/allowJs-ts-check/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/allowJs-ts-check/expectedOutput-4.1/output.txt
@@ -6,6 +6,6 @@ Entrypoint main = bundle.js
 [./src/index.js] 207 bytes {main} [built]
 
 ERROR in src/error2.js
-./src/error2.js
+./src/error2.js 4:9-12
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36msrc/error2.js(4,10)[39m[22m
 [1m[31m      TS2339: Property 'bar' does not exist on type 'Class2'.[39m[22m

--- a/test/comparison-tests/basic/expectedOutput-4.1/patch0/output.txt
+++ b/test/comparison-tests/basic/expectedOutput-4.1/patch0/output.txt
@@ -6,6 +6,6 @@ Entrypoint main = bundle.js
 [./submodule/submodule.ts] 149 bytes {main}
 
 ERROR in app.ts
-./app.ts
+./app.ts 3:12-24
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(3,13)[39m[22m
 [1m[31m      TS2551: Property 'doSomething2' does not exist on type 'typeof externalLib'. Did you mean 'doSomething'?[39m[22m

--- a/test/comparison-tests/colors/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/colors/expectedOutput-4.1/output.txt
@@ -13,6 +13,6 @@ You may need an additional loader to handle the result of these loaders.
 | 
 
 ERROR in app.ts
-./app.ts
+./app.ts 1:6-8
 [tsl] ERROR in app.ts(1,7)
       TS1005: ',' expected.

--- a/test/comparison-tests/colors/expectedOutput-transpile-4.1/output.txt
+++ b/test/comparison-tests/colors/expectedOutput-transpile-4.1/output.txt
@@ -13,6 +13,6 @@ You may need an additional loader to handle the result of these loaders.
 | 
 
 ERROR in app.ts
-./app.ts
+./app.ts 1:6-8
 [tsl] ERROR in app.ts(1,7)
       TS1005: ',' expected.

--- a/test/comparison-tests/declarationDeps/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/declarationDeps/expectedOutput-4.1/output.txt
@@ -4,6 +4,6 @@ Entrypoint main = bundle.js
 [./app.ts] 41 bytes {main} [built] [1 error]
 
 ERROR in app.ts
-./app.ts
+./app.ts 2:6-11
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(2,7)[39m[22m
 [1m[31m      TS2339: Property 'sayHi' does not exist on type 'typeof Hello'.[39m[22m

--- a/test/comparison-tests/declarationWatch/expectedOutput-4.1/patch0/output.txt
+++ b/test/comparison-tests/declarationWatch/expectedOutput-4.1/patch0/output.txt
@@ -5,11 +5,11 @@ Entrypoint main = bundle.js
 [./dep.ts] 59 bytes {main} [built] [1 error]
 
 ERROR in app.ts
-./app.ts
+./app.ts 5:6-17
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(5,7)[39m[22m
 [1m[31m      TS2339: Property 'doSomething' does not exist on type 'typeof Thing'.[39m[22m
 
 ERROR in dep.ts
-./dep.ts
+./dep.ts 1:6-17
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mdep.ts(1,7)[39m[22m
 [1m[31m      TS2339: Property 'doSomething' does not exist on type 'typeof Thing'.[39m[22m

--- a/test/comparison-tests/dependencyErrors/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/dependencyErrors/expectedOutput-4.1/output.txt
@@ -6,11 +6,11 @@ Entrypoint main = bundle.js
 [./dep2.ts] 76 bytes {main} [built]
 
 ERROR in app.ts
-./app.ts
+./app.ts 4:5-7
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(4,6)[39m[22m
 [1m[31m      TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.[39m[22m
 
 ERROR in app.ts
-./app.ts
+./app.ts 5:5-7
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(5,6)[39m[22m
 [1m[31m      TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.[39m[22m

--- a/test/comparison-tests/dependencyErrors/expectedOutput-4.1/patch0/output.txt
+++ b/test/comparison-tests/dependencyErrors/expectedOutput-4.1/patch0/output.txt
@@ -6,6 +6,6 @@ Entrypoint main = bundle.js
 [./dep2.ts] 76 bytes {main}
 
 ERROR in app.ts
-./app.ts
+./app.ts 5:5-7
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(5,6)[39m[22m
 [1m[31m      TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.[39m[22m

--- a/test/comparison-tests/errorFormatter/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/errorFormatter/expectedOutput-4.1/output.txt
@@ -5,5 +5,5 @@ Entrypoint main = bundle.js
 [./common/components/myComponent.ts] 46 bytes {main} [built]
 
 ERROR in app.ts
-./app.ts
+./app.ts 2:30-55
 Does not compute.... [1m[31mcode: 2307,severity: error,content: Cannot find module 'components/myComponent2' or its corresponding type declarations.,file: app.ts,line: 2,character: 31,context: .test/errorFormatter[39m[22m

--- a/test/comparison-tests/errors/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/errors/expectedOutput-4.1/output.txt
@@ -13,6 +13,6 @@ You may need an additional loader to handle the result of these loaders.
 | 
 
 ERROR in app.ts
-./app.ts
+./app.ts 1:6-8
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(1,7)[39m[22m
 [1m[31m      TS1005: ',' expected.[39m[22m

--- a/test/comparison-tests/errors/expectedOutput-transpile-4.1/output.txt
+++ b/test/comparison-tests/errors/expectedOutput-transpile-4.1/output.txt
@@ -4,7 +4,7 @@ Entrypoint main = bundle.js
 [./app.ts] 220 bytes {main} [built] [failed] [2 errors]
 
 ERROR in app.ts
-./app.ts
+./app.ts 1:6-8
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(1,7)[39m[22m
 [1m[31m      TS1005: ',' expected.[39m[22m
 

--- a/test/comparison-tests/es3/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/es3/expectedOutput-4.1/output.txt
@@ -4,6 +4,6 @@ Entrypoint main = bundle.js
 [./app.ts] 29 bytes {main} [built] [1 error]
 
 ERROR in app.ts
-./app.ts
+./app.ts 1:6-7
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(1,7)[39m[22m
 [1m[31m      TS1056: Accessors are only available when targeting ECMAScript 5 and higher.[39m[22m

--- a/test/comparison-tests/ignoreDiagnostics/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/ignoreDiagnostics/expectedOutput-4.1/output.txt
@@ -4,6 +4,6 @@ Entrypoint main = bundle.js
 [./app.ts] 278 bytes {main} [built] [1 error]
 
 ERROR in app.ts
-./app.ts
+./app.ts 9:4-5
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(9,5)[39m[22m
 [1m[31m      TS2322: Type 'string' is not assignable to type 'Number'.[39m[22m

--- a/test/comparison-tests/importsWatch/expectedOutput-4.1/patch1/output.txt
+++ b/test/comparison-tests/importsWatch/expectedOutput-4.1/patch1/output.txt
@@ -4,6 +4,6 @@ Entrypoint main = bundle.js
 [./app.ts] 70 bytes {main} [built] [1 error]
 
 ERROR in app.ts
-./app.ts
+./app.ts 4:0-7
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(4,1)[39m[22m
 [1m[31m      TS2322: Type 'string' is not assignable to type 'boolean'.[39m[22m

--- a/test/comparison-tests/nolib/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/nolib/expectedOutput-4.1/output.txt
@@ -32,6 +32,6 @@ ERROR in tsconfig.json
 [1m[31m      TS2318: Cannot find global type 'RegExp'.[39m[22m
 
 ERROR in app.ts
-./app.ts
+./app.ts 1:0-8
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(1,1)[39m[22m
 [1m[31m      TS2304: Cannot find name 'parseInt'.[39m[22m

--- a/test/comparison-tests/onlyCompileBundledFiles/expectedOutput-4.1/patch0/output.txt
+++ b/test/comparison-tests/onlyCompileBundledFiles/expectedOutput-4.1/patch0/output.txt
@@ -6,6 +6,6 @@ Entrypoint main = bundle.js
 [./submodule/submodule.ts] 149 bytes {main}
 
 ERROR in app.ts
-./app.ts
+./app.ts 3:12-24
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(3,13)[39m[22m
 [1m[31m      TS2551: Property 'doSomething2' does not exist on type 'typeof externalLib'. Did you mean 'doSomething'?[39m[22m

--- a/test/comparison-tests/production/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/production/expectedOutput-4.1/output.txt
@@ -4,6 +4,6 @@ Entrypoint main = bundle.js
 [0] ./app.ts 27 bytes {0} [built] [1 error]
 
 ERROR in app.ts
-./app.ts
+./app.ts 4:0-1
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(4,1)[39m[22m
 [1m[31m      TS2322: Type 'string' is not assignable to type 'number'.[39m[22m

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-4.1/patch3/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-4.1/patch3/output.txt
@@ -8,6 +8,6 @@ Entrypoint main = bundle.js
 [./app.ts] 202 bytes {main} [built]
 
 ERROR in common/index.ts
-../common/index.ts
+../common/index.ts 2:2-12
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mcommon/index.ts(2,3)[39m[22m
 [1m[31m      TS2322: Type 'number' is not assignable to type 'string'.[39m[22m

--- a/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-4.1/patch5/output.txt
+++ b/test/comparison-tests/projectReferencesMultipleDifferentInstance/expectedOutput-4.1/patch5/output.txt
@@ -8,6 +8,6 @@ Entrypoint main = bundle.js
 [./app.ts] 202 bytes {main} [built]
 
 ERROR in utils/index.ts
-../utils/index.ts
+../utils/index.ts 5:35-50
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mutils/index.ts(5,36)[39m[22m
 [1m[31m      TS2322: Type 'string' is not assignable to type 'number'.[39m[22m

--- a/test/comparison-tests/projectReferencesNotBuilt_ErrorInProject/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/projectReferencesNotBuilt_ErrorInProject/expectedOutput-4.1/output.txt
@@ -9,6 +9,6 @@ Entrypoint main = bundle.js
 [./lib/index.ts] 119 bytes {main} [built]
 
 ERROR in app.ts
-./app.ts
+./app.ts 3:45-49
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(3,46)[39m[22m
 [1m[31m      TS2339: Property 'four' does not exist on type '{ one: number; two: number; three: number; }'.[39m[22m

--- a/test/comparison-tests/projectReferencesNotBuilt_ErrorInProject_Composite_WatchApi/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/projectReferencesNotBuilt_ErrorInProject_Composite_WatchApi/expectedOutput-4.1/output.txt
@@ -11,6 +11,6 @@ Entrypoint main = bundle.js
 [./lib/index.ts] 119 bytes {main} [built]
 
 ERROR in app.ts
-./app.ts
+./app.ts 3:45-49
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(3,46)[39m[22m
 [1m[31m      TS2339: Property 'four' does not exist on type '{ one: number; two: number; three: number; }'.[39m[22m

--- a/test/comparison-tests/projectReferencesNotBuilt_ErrorInProject_WatchApi/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/projectReferencesNotBuilt_ErrorInProject_WatchApi/expectedOutput-4.1/output.txt
@@ -9,6 +9,6 @@ Entrypoint main = bundle.js
 [./lib/index.ts] 119 bytes {main} [built]
 
 ERROR in app.ts
-./app.ts
+./app.ts 3:45-49
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(3,46)[39m[22m
 [1m[31m      TS2339: Property 'four' does not exist on type '{ one: number; two: number; three: number; }'.[39m[22m

--- a/test/comparison-tests/projectReferencesNotBuilt_SemanticErrorInReference/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/projectReferencesNotBuilt_SemanticErrorInReference/expectedOutput-4.1/output.txt
@@ -14,6 +14,6 @@ Error: TypeScript emitted no output for lib/index.ts. The most common cause for 
  @ ./app.ts 3:12-28
 
 ERROR in lib/index.ts
-./lib/index.ts
+./lib/index.ts 6:6-7
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib/index.ts(6,7)[39m[22m
 [1m[31m      TS2322: Type 'number' is not assignable to type 'string'.[39m[22m

--- a/test/comparison-tests/projectReferencesNotBuilt_SemanticErrorInReference_Composite_WatchApi/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/projectReferencesNotBuilt_SemanticErrorInReference_Composite_WatchApi/expectedOutput-4.1/output.txt
@@ -16,6 +16,6 @@ Error: TypeScript emitted no output for lib/index.ts. The most common cause for 
  @ ./app.ts 3:12-28
 
 ERROR in lib/index.ts
-./lib/index.ts
+./lib/index.ts 6:6-7
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib/index.ts(6,7)[39m[22m
 [1m[31m      TS2322: Type 'number' is not assignable to type 'string'.[39m[22m

--- a/test/comparison-tests/projectReferencesNotBuilt_SemanticErrorInReference_WatchApi/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/projectReferencesNotBuilt_SemanticErrorInReference_WatchApi/expectedOutput-4.1/output.txt
@@ -14,6 +14,6 @@ Error: TypeScript emitted no output for lib/index.ts. The most common cause for 
  @ ./app.ts 3:12-28
 
 ERROR in lib/index.ts
-./lib/index.ts
+./lib/index.ts 6:6-7
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib/index.ts(6,7)[39m[22m
 [1m[31m      TS2322: Type 'number' is not assignable to type 'string'.[39m[22m

--- a/test/comparison-tests/projectReferencesNotBuilt_SyntaxErrorInReference/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/projectReferencesNotBuilt_SyntaxErrorInReference/expectedOutput-4.1/output.txt
@@ -13,6 +13,6 @@ Error: TypeScript emitted no output for lib/index.ts. The most common cause for 
  @ ./app.ts 3:12-28
 
 ERROR in lib/index.ts
-./lib/index.ts
+./lib/index.ts 4:11-12
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib/index.ts(4,12)[39m[22m
 [1m[31m      TS1136: Property assignment expected.[39m[22m

--- a/test/comparison-tests/projectReferencesNotBuilt_SyntaxErrorInReference_Composite_WatchApi/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/projectReferencesNotBuilt_SyntaxErrorInReference_Composite_WatchApi/expectedOutput-4.1/output.txt
@@ -15,6 +15,6 @@ Error: TypeScript emitted no output for lib/index.ts. The most common cause for 
  @ ./app.ts 3:12-28
 
 ERROR in lib/index.ts
-./lib/index.ts
+./lib/index.ts 4:11-12
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib/index.ts(4,12)[39m[22m
 [1m[31m      TS1136: Property assignment expected.[39m[22m

--- a/test/comparison-tests/projectReferencesNotBuilt_SyntaxErrorInReference_WatchApi/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/projectReferencesNotBuilt_SyntaxErrorInReference_WatchApi/expectedOutput-4.1/output.txt
@@ -13,6 +13,6 @@ Error: TypeScript emitted no output for lib/index.ts. The most common cause for 
  @ ./app.ts 3:12-28
 
 ERROR in lib/index.ts
-./lib/index.ts
+./lib/index.ts 4:11-12
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib/index.ts(4,12)[39m[22m
 [1m[31m      TS1136: Property assignment expected.[39m[22m

--- a/test/comparison-tests/projectReferencesOutDirWithPackageJson/expectedOutput-4.1/patch4/output.txt
+++ b/test/comparison-tests/projectReferencesOutDirWithPackageJson/expectedOutput-4.1/patch4/output.txt
@@ -5,6 +5,6 @@ Entrypoint main = bundle.js
 [./lib/out/index.js] 178 bytes {main} [built]
 
 ERROR in app.ts
-./app.ts
+./app.ts 3:55-60
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(3,56)[39m[22m
 [1m[31m      TS2551: Property 'ffive' does not exist on type '{ one: number; two: number; three: number; four: number; five: number; }'. Did you mean 'five'?[39m[22m

--- a/test/comparison-tests/projectReferencesOutDirWithPackageJsonAlreadyBuilt/expectedOutput-4.1/patch4/output.txt
+++ b/test/comparison-tests/projectReferencesOutDirWithPackageJsonAlreadyBuilt/expectedOutput-4.1/patch4/output.txt
@@ -5,6 +5,6 @@ Entrypoint main = bundle.js
 [./lib/out/index.js] 178 bytes {main} [built]
 
 ERROR in app.ts
-./app.ts
+./app.ts 3:55-60
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(3,56)[39m[22m
 [1m[31m      TS2551: Property 'ffive' does not exist on type '{ one: number; two: number; three: number; four: number; five: number; }'. Did you mean 'five'?[39m[22m

--- a/test/comparison-tests/projectReferencesSymLinks/expectedOutput-4.1/patch0/output.txt
+++ b/test/comparison-tests/projectReferencesSymLinks/expectedOutput-4.1/patch0/output.txt
@@ -9,6 +9,6 @@ Entrypoint main = index.js
 [./src/index.ts] 108 bytes {main} [built] [1 error]
 
 ERROR in app/src/index.ts
-./src/index.ts
+./src/index.ts 1:9-25
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp/src/index.ts(1,10)[39m[22m
 [1m[31m      TS2724: '"../../lib/dist"' has no exported member named 'getMeaningOfLife'. Did you mean 'getMeaningOfLife3'?[39m[22m

--- a/test/comparison-tests/projectReferencesSymLinksPreserve/expectedOutput-4.1/patch0/output.txt
+++ b/test/comparison-tests/projectReferencesSymLinksPreserve/expectedOutput-4.1/patch0/output.txt
@@ -9,6 +9,6 @@ Entrypoint main = index.js
 [./src/index.ts] 108 bytes {main} [built] [1 error]
 
 ERROR in app/src/index.ts
-./src/index.ts
+./src/index.ts 1:9-25
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp/src/index.ts(1,10)[39m[22m
 [1m[31m      TS2724: '"../../node_modules/lib/dist"' has no exported member named 'getMeaningOfLife'. Did you mean 'getMeaningOfLife3'?[39m[22m

--- a/test/comparison-tests/projectReferencesSymLinksPreserve_WatchApi/expectedOutput-4.1/patch0/output.txt
+++ b/test/comparison-tests/projectReferencesSymLinksPreserve_WatchApi/expectedOutput-4.1/patch0/output.txt
@@ -9,6 +9,6 @@ Entrypoint main = index.js
 [./src/index.ts] 108 bytes {main} [built] [1 error]
 
 ERROR in app/src/index.ts
-./src/index.ts
+./src/index.ts 1:9-25
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp/src/index.ts(1,10)[39m[22m
 [1m[31m      TS2724: '"../../node_modules/lib/dist"' has no exported member named 'getMeaningOfLife'. Did you mean 'getMeaningOfLife3'?[39m[22m

--- a/test/comparison-tests/projectReferencesSymLinks_WatchApi/expectedOutput-4.1/patch0/output.txt
+++ b/test/comparison-tests/projectReferencesSymLinks_WatchApi/expectedOutput-4.1/patch0/output.txt
@@ -9,6 +9,6 @@ Entrypoint main = index.js
 [./src/index.ts] 108 bytes {main} [built] [1 error]
 
 ERROR in app/src/index.ts
-./src/index.ts
+./src/index.ts 1:9-25
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp/src/index.ts(1,10)[39m[22m
 [1m[31m      TS2724: '"../../lib/dist"' has no exported member named 'getMeaningOfLife'. Did you mean 'getMeaningOfLife3'?[39m[22m

--- a/test/comparison-tests/projectReferencesWatch/expectedOutput-4.1/patch2/output.txt
+++ b/test/comparison-tests/projectReferencesWatch/expectedOutput-4.1/patch2/output.txt
@@ -5,11 +5,11 @@ Entrypoint main = bundle.js
 [./lib/index.ts] 150 bytes {main} [built] [2 errors]
 
 ERROR in lib/index.ts
-./lib/index.ts
+./lib/index.ts 6:2-3
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib/index.ts(6,3)[39m[22m
 [1m[31m      TS1136: Property assignment expected.[39m[22m
 
 ERROR in lib/index.ts
-./lib/index.ts
+./lib/index.ts 7:0-1
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib/index.ts(7,1)[39m[22m
 [1m[31m      TS1128: Declaration or statement expected.[39m[22m

--- a/test/comparison-tests/projectReferencesWatch/expectedOutput-4.1/patch4/output.txt
+++ b/test/comparison-tests/projectReferencesWatch/expectedOutput-4.1/patch4/output.txt
@@ -5,6 +5,6 @@ Entrypoint main = bundle.js
 [./lib/index.ts] 145 bytes {main}
 
 ERROR in app.ts
-./app.ts
+./app.ts 3:55-60
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(3,56)[39m[22m
 [1m[31m      TS2551: Property 'ffive' does not exist on type '{ one: number; two: number; three: number; four: number; five: number; }'. Did you mean 'five'?[39m[22m

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-4.1/patch2/output.txt
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-4.1/patch2/output.txt
@@ -6,11 +6,11 @@ Entrypoint main = bundle.js
 [./lib/index.ts] 150 bytes {main} [built] [2 errors]
 
 ERROR in lib/index.ts
-./lib/index.ts
+./lib/index.ts 6:2-3
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib/index.ts(6,3)[39m[22m
 [1m[31m      TS1136: Property assignment expected.[39m[22m
 
 ERROR in lib/index.ts
-./lib/index.ts
+./lib/index.ts 7:0-1
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib/index.ts(7,1)[39m[22m
 [1m[31m      TS1128: Declaration or statement expected.[39m[22m

--- a/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-4.1/patch4/output.txt
+++ b/test/comparison-tests/projectReferencesWatch_Composite_WatchApi/expectedOutput-4.1/patch4/output.txt
@@ -7,6 +7,6 @@ Entrypoint main = bundle.js
 [./lib/index.ts] 145 bytes {main}
 
 ERROR in app.ts
-./app.ts
+./app.ts 3:55-60
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(3,56)[39m[22m
 [1m[31m      TS2551: Property 'ffive' does not exist on type '{ one: number; two: number; three: number; four: number; five: number; }'. Did you mean 'five'?[39m[22m

--- a/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-4.1/patch2/output.txt
+++ b/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-4.1/patch2/output.txt
@@ -5,11 +5,11 @@ Entrypoint main = bundle.js
 [./lib/index.ts] 150 bytes {main} [built] [2 errors]
 
 ERROR in lib/index.ts
-./lib/index.ts
+./lib/index.ts 6:2-3
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib/index.ts(6,3)[39m[22m
 [1m[31m      TS1136: Property assignment expected.[39m[22m
 
 ERROR in lib/index.ts
-./lib/index.ts
+./lib/index.ts 7:0-1
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mlib/index.ts(7,1)[39m[22m
 [1m[31m      TS1128: Declaration or statement expected.[39m[22m

--- a/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-4.1/patch4/output.txt
+++ b/test/comparison-tests/projectReferencesWatch_WatchApi/expectedOutput-4.1/patch4/output.txt
@@ -5,6 +5,6 @@ Entrypoint main = bundle.js
 [./lib/index.ts] 145 bytes {main}
 
 ERROR in app.ts
-./app.ts
+./app.ts 3:55-60
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(3,56)[39m[22m
 [1m[31m      TS2551: Property 'ffive' does not exist on type '{ one: number; two: number; three: number; four: number; five: number; }'. Did you mean 'five'?[39m[22m

--- a/test/comparison-tests/reportFiles/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/reportFiles/expectedOutput-4.1/output.txt
@@ -5,6 +5,6 @@ Entrypoint main = bundle.js
 [./skip.ts] 79 bytes {main} [built]
 
 ERROR in app.ts
-./app.ts
+./app.ts 3:0-1
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(3,1)[39m[22m
 [1m[31m      TS2322: Type 'string' is not assignable to type 'number'.[39m[22m

--- a/test/comparison-tests/simpleDependency/expectedOutput-4.1/patch0/output.txt
+++ b/test/comparison-tests/simpleDependency/expectedOutput-4.1/patch0/output.txt
@@ -6,6 +6,6 @@ Entrypoint main = bundle.js
 [./dep.ts] 70 bytes {main} [built]
 
 ERROR in app.ts
-./app.ts
+./app.ts 3:4-6
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(3,5)[39m[22m
 [1m[31m      TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.[39m[22m

--- a/test/comparison-tests/typeSystemWatch/expectedOutput-4.1/patch0/output.txt
+++ b/test/comparison-tests/typeSystemWatch/expectedOutput-4.1/patch0/output.txt
@@ -4,6 +4,6 @@ Entrypoint main = bundle.js
 [./app.ts] 212 bytes {main} [built] [1 error]
 
 ERROR in app.ts
-./app.ts
+./app.ts 11:4-5
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(11,5)[39m[22m
 [1m[31m      TS2741: Property 'b' is missing in type 'AType' but required in type 'BType'.[39m[22m


### PR DESCRIPTION
This PR adds the `loc` property to all errors coming from TypeScript diagnostics.
The property is the webpack "API" way of indicating the precise location of an error, including its _end_ location.
In this way, the errors produced by `ts-loader` can be processed from the webpack `Stats` object, with no knowledge of `ts-loader`.

The previous location property is still available, so the change is backward-compatible.

Webpack will print its own error location string in the string output, in addition to the line and character that `ts-loader` already includes in the error message. All comparison tests are updated to expect the new output.

Closes #1199