### PR TITLE
feat: remove top-level typescript import statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v8.1.0
+* [feat: remove top-level typescript import statements](https://github.com/TypeStrong/ts-loader/pull/1259) - thanks @ulivz
+
 ## v8.0.18
 * [Perf: Optimize fileExists callback path](https://github.com/TypeStrong/ts-loader/issues/1266) - thanks @berickson1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.0.18",
+  "version": "8.1.0",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/after-compile.ts
+++ b/src/after-compile.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import * as ts from 'typescript';
+import type * as ts from 'typescript';
 import * as webpack from 'webpack';
 
 import * as constants from './constants';

--- a/src/compilerSetup.ts
+++ b/src/compilerSetup.ts
@@ -1,5 +1,5 @@
 import * as semver from 'semver';
-import * as typescript from 'typescript';
+import type * as typescript from 'typescript';
 
 import { LoaderOptions } from './interfaces';
 import * as logger from './logger';
@@ -52,7 +52,8 @@ export function getCompiler(loaderOptions: LoaderOptions, log: logger.Logger) {
 }
 
 export function getCompilerOptions(
-  configParseResult: typescript.ParsedCommandLine
+  configParseResult: typescript.ParsedCommandLine,
+  compiler: typeof typescript
 ) {
   const compilerOptions = Object.assign({}, configParseResult.options, {
     skipLibCheck: true,
@@ -63,9 +64,9 @@ export function getCompilerOptions(
   if (
     compilerOptions.module === undefined &&
     compilerOptions.target !== undefined &&
-    compilerOptions.target < typescript.ScriptTarget.ES2015
+    compilerOptions.target < compiler.ScriptTarget.ES2015
   ) {
-    compilerOptions.module = typescript.ModuleKind.CommonJS;
+    compilerOptions.module = compiler.ModuleKind.CommonJS;
   }
 
   if (configParseResult.options.configFile) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { Chalk } from 'chalk';
 import * as path from 'path';
-import * as typescript from 'typescript';
+import type * as typescript from 'typescript';
 import * as webpack from 'webpack';
 
 import { getCompilerOptions } from './compilerSetup';
@@ -187,7 +187,7 @@ export function getParsedCommandLine(
     extendedConfigCache
   );
   if (result) {
-    result.options = getCompilerOptions(result);
+    result.options = getCompilerOptions(result, compiler);
   }
   return result;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as crypto from 'crypto';
 import * as loaderUtils from 'loader-utils';
 import * as path from 'path';
-import * as typescript from 'typescript';
+import type * as typescript from 'typescript';
 import * as webpack from 'webpack';
 
 import * as constants from './constants';

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -1,7 +1,7 @@
 import * as chalk from 'chalk';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as typescript from 'typescript';
+import type * as typescript from 'typescript';
 import * as webpack from 'webpack';
 
 import { makeAfterCompile } from './after-compile';
@@ -202,7 +202,7 @@ function successfulTypeScriptInstance(
     };
   }
 
-  const compilerOptions = getCompilerOptions(configParseResult);
+  const compilerOptions = getCompilerOptions(configParseResult, compiler);
   const rootFileNames = new Set<string>();
   const files: TSFiles = new Map();
   const otherFiles: TSFiles = new Map();

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import * as typescript from 'typescript';
+import type * as typescript from 'typescript';
 
 import { Chalk } from 'chalk';
 import * as logger from './logger';

--- a/src/servicesHost.ts
+++ b/src/servicesHost.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import * as typescript from 'typescript';
+import type * as typescript from 'typescript';
 import * as webpack from 'webpack';
 import { getParsedCommandLine } from './config';
 import * as constants from './constants';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import { Chalk } from 'chalk';
 import * as fs from 'fs';
 import * as micromatch from 'micromatch';
 import * as path from 'path';
-import * as typescript from 'typescript';
+import type * as typescript from 'typescript';
 
 import constants = require('./constants');
 import {


### PR DESCRIPTION
## Background

In some deployment systems, the builder and source code are placed in different paths, and we also expect the typescript's version to be completely controlled by the user, if the builder does not depend on `typescript`, then we will get error containing `cannot found "typescript"` caused by the top-level typescript import statement at `ts-loader`, In other words, **_we SHOULD respect the resolved compiler_**.

Prior to TypeScript 3.8, you can import a type using import. With TypeScript 3.8, you can import a type using the import statement, or using `import type`, and import type is always guaranteed to be removed from your JavaScript, this project has stopped testing TypeScript 3.6 and 3.7 at [953358e](https://github.com/TypeStrong/ts-loader/commit/953358eb1b090dd9add0824c4746220b0ebe56c1), so usage of `import type` is allowed here.

This pull request replaced all remove top-level typescript `import` statements with `import type`, and leverage constants from resolved compiler.




