### PR TITLE
Optimize fileExists callback path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v8.0.18
+* [Perf: Optimize fileExists callback path](https://github.com/TypeStrong/ts-loader/issues/1266) - thanks @berickson1
+
 ## v8.0.17
 * [Included correct webpack source location in emitted errors](https://github.com/TypeStrong/ts-loader/issues/1199) - thanks @lorenzodallavecchia
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.0.17",
+  "version": "8.0.18",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/servicesHost.ts
+++ b/src/servicesHost.ts
@@ -683,10 +683,14 @@ export function makeSolutionBuilderHost(
     scriptRegex,
     loader,
     instance,
-    fileName =>
-      !!instance.files.has(filePathKeyMapper(fileName)) ||
-      !!instance.otherFiles.get(filePathKeyMapper(fileName)) ||
-      compiler.sys.fileExists(fileName),
+    fileName => {
+      const filePathKey = filePathKeyMapper(fileName);
+      return (
+        instance.files.has(filePathKey) ||
+        instance.otherFiles.has(filePathKey) ||
+        compiler.sys.fileExists(fileName)
+      );
+    },
     /*enableFileCaching*/ true
   );
 


### PR DESCRIPTION
Instead of looking up filePathKey twice, cache in in the local scope. This isn't a hugely expensive lookup path, but is a hot path on large project recompiles (especially after caches are blown away). Profiling shows that even the Map lookup shows non-trivial cache lookup aggregate time. (Less than a non-cached implementation though :) )
<img width="650" alt="Screen Shot 2021-03-10 at 1 32 07 PM" src="https://user-images.githubusercontent.com/1418465/110703301-760d3d00-81a8-11eb-9cff-23b663ddf81f.png">
