### PR TITLE
UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'fileName' of undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v9.1.2
+
+* [Fix removed files handling in watch mode](https://github.com/TypeStrong/ts-loader/pull/1293) - thanks @gasnier
+
 ## v9.1.1
 
 * [update CHANGELOG.md for 8.2.0 release](https://github.com/TypeStrong/ts-loader/pull/1291) - thanks @johnnyreilly

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/after-compile.ts
+++ b/src/after-compile.ts
@@ -184,7 +184,8 @@ function determineFilesToCheckForErrors(
   return filesToCheckForErrors;
 
   function addFileToCheckForErrors(filePath: FilePathKey, file: TSFile) {
-    if (!isReferencedFile(instance, filePath)) {
+    //file can sometimes be undefined when using webpack devserver
+    if (file && !isReferencedFile(instance, filePath)) {
       filesToCheckForErrors.set(filePath, file);
     }
   }

--- a/src/after-compile.ts
+++ b/src/after-compile.ts
@@ -186,7 +186,6 @@ function determineFilesToCheckForErrors(
   return filesToCheckForErrors;
 
   function addFileToCheckForErrors(filePath: FilePathKey, file: TSFile) {
-    //file can sometimes be undefined when using webpack devserver
     if (file && !isReferencedFile(instance, filePath)) {
       filesToCheckForErrors.set(filePath, file);
     }

--- a/src/after-compile.ts
+++ b/src/after-compile.ts
@@ -170,7 +170,9 @@ function determineFilesToCheckForErrors(
       ).keys()) {
         const fileToCheckForErrors =
           files.get(fileName) || otherFiles.get(fileName);
-        addFileToCheckForErrors(fileName, fileToCheckForErrors!);
+        if (fileToCheckForErrors) {//file may have been removed
+          addFileToCheckForErrors(fileName, fileToCheckForErrors);
+        }
       }
     }
   }


### PR DESCRIPTION
When using webpack devserver I often get an Unhandled promise rejection when a file is removed (generally because I switch to another git branch)
I get UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'fileName' of undefined
    at provideErrorsToWebpack (after-compile.js:128:29)

 (I assume it may also happen while simply using watch mode)

Without the provided fix, I need to stop and restart the devserver to solve the problem