### PR TITLE
Add webpack minimum version in peerDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v9.2.2
+
+* [Add webpack minimum version in peerDependencies](https://github.com/TypeStrong/ts-loader/issues/1324) - thanks @afdev82
+
 ## v9.2.1
 
 * [Make v9 latest in npm again](https://github.com/TypeStrong/ts-loader/issues/1320) - thanks @johnnyreilly

--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
   },
   "peerDependencies": {
     "typescript": "*",
-    "webpack": "*"
+    "webpack": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",


### PR DESCRIPTION
I added the minimum webpack version in the peerDependencies section of package.json.
See also #1323