### PR TITLE
getCustomTransformers error message fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v9.2.3
+
+* [Fix error message for invalid getCustomTransformers modules](https://github.com/TypeStrong/ts-loader/issues/1334) - thanks @blaky
+
 ## v9.2.2
 
 * [Start consuming webpack loader types](https://github.com/TypeStrong/ts-loader/issues/1325) - thanks @johnnyreilly

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "9.2.2",
+  "version": "9.2.3",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -361,7 +361,7 @@ export function initializeInstance(
       throw new Error(
         `Custom transformers in "${
           instance.loaderOptions.getCustomTransformers
-        }" should export a function, got ${typeof getCustomTransformers}`
+        }" should export a function, got ${typeof customerTransformers}`
       );
     }
     getCustomTransformers = customerTransformers;
@@ -403,10 +403,10 @@ export function initializeInstance(
         instance,
         instance.configParseResult.projectReferences
       );
-      instance.watchOfFilesAndCompilerOptions = instance.compiler.createWatchProgram(
-        instance.watchHost
-      );
-      instance.builderProgram = instance.watchOfFilesAndCompilerOptions.getProgram();
+      instance.watchOfFilesAndCompilerOptions =
+        instance.compiler.createWatchProgram(instance.watchHost);
+      instance.builderProgram =
+        instance.watchOfFilesAndCompilerOptions.getProgram();
       instance.program = instance.builderProgram.getProgram();
 
       instance.transformers = getCustomTransformers(instance.program);


### PR DESCRIPTION
The error message here was misleading, it wasn't reporting on the same variable that it checks in line 360. If ts-loader was configured with a `getCustomTransformers` function that returned a module path which didn't had a `module.exports = function(){..}` in it, the error message displayed was the following: `... should export a function, got function`.