### PR TITLE
getCustomTransformer program mismatch

### DIFF
--- a/src/instances.ts
+++ b/src/instances.ts
@@ -368,17 +368,12 @@ export function initializeInstance(
   }
 
   if (instance.loaderOptions.transpileOnly) {
-    const program = (instance.program =
-      instance.configParseResult.projectReferences !== undefined
-        ? instance.compiler.createProgram({
-            rootNames: instance.configParseResult.fileNames,
-            options: instance.configParseResult.options,
-            projectReferences: instance.configParseResult.projectReferences,
-          })
-        : instance.compiler.createProgram([], instance.compilerOptions));
-
-    const getProgram = () => program;
-    instance.transformers = getCustomTransformers(program, getProgram);
+    instance.program = instance.compiler.createProgram({
+      rootNames: instance.configParseResult.fileNames.filter(fs.existsSync),
+      options: instance.configParseResult.options,
+      projectReferences: instance.configParseResult.projectReferences,
+    });
+    instance.transformers = getCustomTransformers(instance.program);
     // Setup watch run for solution building
     if (instance.solutionBuilderHost) {
       addAssetHooks(loader, instance);

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -373,7 +373,8 @@ export function initializeInstance(
       options: instance.configParseResult.options,
       projectReferences: instance.configParseResult.projectReferences,
     });
-    instance.transformers = getCustomTransformers(instance.program);
+    const getProgram = () => instance.program;
+    instance.transformers = getCustomTransformers(instance.program, getProgram);
     // Setup watch run for solution building
     if (instance.solutionBuilderHost) {
       addAssetHooks(loader, instance);

--- a/test/comparison-tests/customTransformer/webpack.config.js
+++ b/test/comparison-tests/customTransformer/webpack.config.js
@@ -17,12 +17,9 @@ module.exports = {
                 test: /\.ts$/,
                 loader: 'ts-loader',
                 options: {
-                    getCustomTransformers: (program) => {
-                        console.log('program.getSourceFiles():', program.getSourceFiles().map(x => x.fileName));
-                        return ({
-                            before: [uppercaseStringLiteralTransformer]
-                        });
-                    }
+                    getCustomTransformers: (program) => ({
+                        before: [uppercaseStringLiteralTransformer]
+                    })
                 }
             }
         ]

--- a/test/comparison-tests/customTransformer/webpack.config.js
+++ b/test/comparison-tests/customTransformer/webpack.config.js
@@ -17,9 +17,12 @@ module.exports = {
                 test: /\.ts$/,
                 loader: 'ts-loader',
                 options: {
-                    getCustomTransformers: (program) => ({
-                        before: [uppercaseStringLiteralTransformer]
-                    })
+                    getCustomTransformers: (program) => {
+                        console.log('program.getSourceFiles():', program.getSourceFiles().map(x => x.fileName));
+                        return ({
+                            before: [uppercaseStringLiteralTransformer]
+                        });
+                    }
                 }
             }
         ]


### PR DESCRIPTION
Not sure how to fit into the test framework yet.

```
 yarn run comparison-tests -- --single-test customTransformer 
```

Should print out a list of files for non-transpileOnly, empty array for transpile only. Expected a list of files for both.