### PR TITLE
Chore: disable GitHub Linguist detection for tests files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 *.ts eol=lf
 *.js eol=lf
+
+test/** linguist-detectable=false


### PR DESCRIPTION
It makes TypeScript become the top language.