### PR TITLE
Feature: allow for custom writeFile method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !index.js
 /src/*.js
 /src/.vscode
+/.idea
 /*.d.ts
 /*.log
 *.js.map

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,6 +218,7 @@ const validLoaderOptions: ValidLoaderOptions[] = [
   'appendTsxSuffixTo',
   'onlyCompileBundledFiles',
   'happyPackMode',
+  'writeFile',
   'getCustomTransformers',
   'reportFiles',
   'experimentalWatchApi',

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -786,7 +786,10 @@ export function getEmitOutput(instance: TSInstance, filePath: string) {
       fileName: string,
       text: string,
       writeByteOrderMark: boolean
-    ) => outputFiles.push({ name: fileName, writeByteOrderMark, text });
+    ) => {
+      outputFiles.push({ name: fileName, writeByteOrderMark, text });
+      instance.loaderOptions?.writeFile?.(fileName, text, writeByteOrderMark);
+    };
     const outputFilesFromWatch = getEmitFromWatchHost(instance, filePath);
     if (outputFilesFromWatch) {
       return outputFilesFromWatch;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -267,6 +267,11 @@ export interface LoaderOptions {
   appendTsSuffixTo: (RegExp | string)[];
   appendTsxSuffixTo: (RegExp | string)[];
   happyPackMode: boolean;
+  writeFile: (
+    fileName: string,
+    text: string,
+    writeByteOrderMark: boolean
+  ) => void;
   getCustomTransformers:
     | string
     | ((


### PR DESCRIPTION
Disclaimer: what I'm doing here is probably wrong, but any guidance and direction is greatly appreciated!

I'm working on a project that uses typescript's compilerHost.writeFile functionality to evaluate `d.ts` files and adds//modifies additional typings. In order to use ts-loader, I need to be able to use into the same writeFile functionality.

The below "works", but I've seen quite a few other places where compilers get created. I'm sure I've missed a few things. If you could point me in the correct direction for anything else that needs to change, or any recommendations, I'll be glad to adjust and make the changes.

Once there's more of an agreement on direction, I will put in tests and update documentation.

Thanks for any and all help!