### PR TITLE
cater for change in resolveTypeReferenceDirective API in TypeScript 4.7

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -48,7 +48,7 @@ jobs:
     name: Execution Tests Ubuntu
     strategy:
       matrix:
-        node: [12, 14]
+        node: [14, 16]
         ts: [3.8.3, 3.9.3, 4.0.3, 4.1.5, 4.2.4, 4.3.2, 4.4.2, 4.5.2, next]
     runs-on: ubuntu-latest
     steps:
@@ -75,7 +75,7 @@ jobs:
     name: Execution Tests Windows
     strategy:
       matrix:
-        node: [12, 14]
+        node: [14, 16]
         ts: [3.8.3, 3.9.3, 4.0.3, 4.1.5, 4.2.4, 4.3.2, 4.4.2, 4.5.2, next]
     runs-on: windows-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: install node
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
           registry-url: https://registry.npmjs.org/
 
       - name: install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v9.2.7
+
+* [cater for change in resolveTypeReferenceDirective API in TypeScript 4.7](https://github.com/TypeStrong/ts-loader/pull/1422)  [#1421] - thanks @johnny_reilly and @cspotcode for inspiration in ts-node work here: https://github.com/TypeStrong/ts-node/pull/1648
+
+## v9.2.6
+
+* [Docs fix for thread-loader / history](https://github.com/TypeStrong/ts-loader/pull/1377) - thanks @johnnyreilly
+
 ## v9.2.5
 
 * [Add function to get the latest program](https://github.com/TypeStrong/ts-loader/pull/1352) - thanks @Zn4rK

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "9.2.6",
+  "version": "9.2.7",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -307,4 +307,29 @@ export interface ResolvedModule {
   isExternalLibraryImport?: boolean;
 }
 
+export interface TSCommon {
+  // Changed in TS 4.7
+  resolveTypeReferenceDirective(
+    typeReferenceDirectiveName: string,
+    containingFile: string | undefined,
+    options: typescript.CompilerOptions,
+    host: typescript.ModuleResolutionHost,
+    redirectedReference?: typescript.ResolvedProjectReference,
+    cache?: typescript.TypeReferenceDirectiveResolutionCache,
+    resolutionMode?: typescript.SourceFile['impliedNodeFormat']
+  ): typescript.ResolvedTypeReferenceDirectiveWithFailedLookupLocations;
+}
+
+/**
+ * Compiler APIs we use that are marked internal and not included in TypeScript's public API declarations
+ * @internal
+ */
+export interface TSInternal {
+  // Added in TS 4.7
+  getModeForFileReference?: (
+    ref: typescript.FileReference | string,
+    containingFileMode: typescript.SourceFile['impliedNodeFormat']
+  ) => typescript.SourceFile['impliedNodeFormat'];
+}
+
 export type Severity = 'error' | 'warning';


### PR DESCRIPTION
Speculative fix for #1421 - based on @cspotcode's `ts-node` work here: https://github.com/TypeStrong/ts-node/pull/1648

This has been tested on https://github.com/mjbvz/ts-47-webpack-error mentioned by @mjbvz here: https://github.com/microsoft/TypeScript/issues/48020

Using the initial `git clone` of the test repo, it errors out as expected:

```shell
 john@john-XPS-13-9343  ~/code/github/ts-47-webpack-error   main  yarn
yarn install v1.22.5
info No lockfile found.
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...

success Saved lockfile.
Done in 13.70s.
 john@john-XPS-13-9343  ~/code/github/ts-47-webpack-error   main  yarn build
yarn run v1.22.5
$ webpack
assets by status 1.21 KiB [cached] 1 asset
./src/index.ts 39 bytes [built] [code generated] [1 error]

ERROR in ./src/index.ts
Module build failed (from ./node_modules/ts-loader/index.js):
TypeError: path.indexOf is not a function
    at normalizeSlashes (/home/john/code/github/ts-47-webpack-error/node_modules/typescript/lib/typescript.js:7691:26)
    at Object.combinePaths (/home/john/code/github/ts-47-webpack-error/node_modules/typescript/lib/typescript.js:7757:28)
    at /home/john/code/github/ts-47-webpack-error/node_modules/typescript/lib/typescript.js:41935:40
    at Object.firstDefined (/home/john/code/github/ts-47-webpack-error/node_modules/typescript/lib/typescript.js:407:26)
    at primaryLookup (/home/john/code/github/ts-47-webpack-error/node_modules/typescript/lib/typescript.js:41934:27)
    at Object.resolveTypeReferenceDirective (/home/john/code/github/ts-47-webpack-error/node_modules/typescript/lib/typescript.js:41893:24)
    at /home/john/code/github/ts-47-webpack-error/node_modules/ts-loader/dist/servicesHost.js:713:18
    at /home/john/code/github/ts-47-webpack-error/node_modules/ts-loader/dist/servicesHost.js:128:141
    at Array.map (<anonymous>)
    at Object.resolveTypeReferenceDirectives (/home/john/code/github/ts-47-webpack-error/node_modules/ts-loader/dist/servicesHost.js:128:124)

webpack 5.69.1 compiled with 1 error in 750 ms
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Then when linking in this updated version, it appears to work:

```shell
  john@john-XPS-13-9343  ~/code/github/ts-47-webpack-error   main  yarn link "ts-loader"
yarn link v1.22.5
success Using linked package for "ts-loader".
Done in 0.18s.
 john@john-XPS-13-9343  ~/code/github/ts-47-webpack-error   main  yarn build           
yarn run v1.22.5
$ webpack
asset index.js 17 bytes [emitted] [minimized] (name: index)
./src/index.ts 18 bytes [built] [code generated]
webpack 5.69.1 compiled successfully in 3256 ms
Done in 4.40s.
```