### PR TITLE
Bug fix: support webpack 5 in ts-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## v9.2.8
+
+* [Bug fix: support webpack 5 in ts-loader](https://github.com/TypeStrong/ts-loader/pull/1439) [#1438] - thanks @einatbar
+
 ## v9.2.7
 
-* [cater for change in resolveTypeReferenceDirective API in TypeScript 4.7](https://github.com/TypeStrong/ts-loader/pull/1422)  [#1421] - thanks @johnny_reilly and @cspotcode for inspiration in ts-node work here: https://github.com/TypeStrong/ts-node/pull/1648
+* [cater for change in resolveTypeReferenceDirective API in TypeScript 4.7](https://github.com/TypeStrong/ts-loader/pull/1422) [#1421] - thanks @johnny_reilly and @cspotcode for inspiration in ts-node work here: https://github.com/TypeStrong/ts-node/pull/1648
 
 ## v9.2.6
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "9.2.7",
+  "version": "9.2.8",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/watch-run.ts
+++ b/src/watch-run.ts
@@ -29,8 +29,8 @@ export function makeWatchRun(
     if (instance.loaderOptions.transpileOnly) {
       instance.reportTranspileErrors = true;
     } else {
-      compiler.hooks.compilation.tap('ts-loader', compiliation => {
-        compiliation.fileSystemInfo._fileTimestamps.stack.forEach(times => {
+      const times = compiler.fileTimestamps;
+      if (times) {
           for (const [filePath, date] of times) {
             const key = instance.filePathKeyMapper(filePath);
             const lastTime = lastTimes.get(key) || startTime;
@@ -58,9 +58,8 @@ export function makeWatchRun(
                 updateFile(instance, key, fileName, loader, loaderIndex)
               );
             }
-          }
-        })
-      })
+         }
+      }
     }
 
     // Update all the watched files from solution builder


### PR DESCRIPTION
Fixes Error when running ts-loader with webpack 5 : "times is not iterable"

closes #1438 