### PR TITLE
Webpack 4 resolve type references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v8.3.0
+
+* [Fixed impossibility to have several instances of ts-loader with different compiler options](https://github.com/TypeStrong/ts-loader/issues/1316) - thanks @timocov
+* This is a backport from v9.2.0 for webpack 4 compatibility
+
 ## v8.2.0
 
 * [Use caches for module resolution and type reference directives when using compiler default functions](https://github.com/TypeStrong/ts-loader/pull/1287) - thanks @sheetalkamat - uses: https://github.com/microsoft/TypeScript/pull/43700

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v8.2.0
+
+* [Use caches for module resolution and type reference directives when using compiler default functions](https://github.com/TypeStrong/ts-loader/pull/1287) - thanks @sheetalkamat - uses: https://github.com/microsoft/TypeScript/pull/43700
+* This is a backport from v9.1.0 for webpack 4 compatibility
+
 ## v8.1.0
 * [feat: remove top-level typescript import statements](https://github.com/TypeStrong/ts-loader/pull/1259) - thanks @ulivz
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "mocha": "^6.0.0",
     "prettier": "^2.0.5",
     "rimraf": "^2.6.2",
-    "typescript": "^4.0.0",
+    "typescript": "^4.6.3",
     "webpack": "^4.5.0",
     "webpack-cli": "^3.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,8 +161,10 @@ function getOptionsHash(loaderOptions: LoaderOptions) {
   const hash = crypto.createHash('sha256');
   Object.keys(loaderOptions).forEach(key => {
     const value = loaderOptions[key];
-    if (value) {
-      hash.update(key + value.toString());
+    if (value !== undefined) {
+      const valueString =
+        typeof value === 'function' ? value.toString() : JSON.stringify(value);
+      hash.update(key + valueString);
     }
   });
   return hash.digest('hex').substring(0, 16);

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -378,6 +378,7 @@ export function initializeInstance(
   } else if (typeof customerTransformers === 'string') {
     try {
       customerTransformers = require(customerTransformers);
+      // eslint-disable-next-line prettier/prettier
     } catch (err) {
       throw new Error(
         `Failed to load customTransformers from "${instance.loaderOptions.getCustomTransformers}": ${err.message}`

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -198,6 +198,7 @@ interface PerModuleNameCache {
     result: typescript.ResolvedModuleWithFailedLookupLocations
   ): void;
 }
+
 export interface ModuleResolutionCache
   extends typescript.ModuleResolutionCache {
   directoryToModuleNameMap: CacheWithRedirects<
@@ -206,8 +207,8 @@ export interface ModuleResolutionCache
   moduleNameToDirectoryMap: CacheWithRedirects<PerModuleNameCache>;
   clear(): void;
   update(compilerOptions: typescript.CompilerOptions): void;
-  getPackageJsonInfoCache?(): any;
 }
+
 // Until the API has been released and ts-loader is built against a version of TypeScript that contains it - see https://github.com/microsoft/TypeScript/blob/74993a2a64bb2e423b40204bb54ff749cdd4ef54/src/compiler/moduleNameResolver.ts#L458
 export interface TypeReferenceDirectiveResolutionCache {
   getOrCreateCacheForDirectory(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -102,8 +102,9 @@ export interface ServiceHostWhichMayBeCacheable
 
 export interface WatchHost
   extends typescript.WatchCompilerHostOfFilesAndCompilerOptions<
-    typescript.EmitAndSemanticDiagnosticsBuilderProgram
-  > {
+      typescript.EmitAndSemanticDiagnosticsBuilderProgram
+    >,
+    HostMayBeCacheable {
   invokeFileWatcher: WatchFactory['invokeFileWatcher'];
   updateRootFileNames(): void;
   outputFiles: Map<FilePathKey, typescript.OutputFile[]>;
@@ -178,6 +179,47 @@ export interface ConfigFileInfo {
   dtsFiles?: string[];
 }
 
+interface CacheWithRedirects<T> {
+  ownMap: Map<string, T>;
+  redirectsMap: Map<typescript.Path, Map<string, T>>;
+  getOrCreateMapOfCacheRedirects(
+    redirectedReference: typescript.ResolvedProjectReference | undefined
+  ): Map<string, T>;
+  clear(): void;
+  setOwnOptions(newOptions: typescript.CompilerOptions): void;
+  setOwnMap(newOwnMap: Map<string, T>): void;
+}
+interface PerModuleNameCache {
+  get(
+    directory: string
+  ): typescript.ResolvedModuleWithFailedLookupLocations | undefined;
+  set(
+    directory: string,
+    result: typescript.ResolvedModuleWithFailedLookupLocations
+  ): void;
+}
+export interface ModuleResolutionCache
+  extends typescript.ModuleResolutionCache {
+  directoryToModuleNameMap: CacheWithRedirects<
+    Map<string, typescript.ResolvedModuleWithFailedLookupLocations>
+  >;
+  moduleNameToDirectoryMap: CacheWithRedirects<PerModuleNameCache>;
+  clear(): void;
+  update(compilerOptions: typescript.CompilerOptions): void;
+  getPackageJsonInfoCache?(): any;
+}
+// Until the API has been released and ts-loader is built against a version of TypeScript that contains it - see https://github.com/microsoft/TypeScript/blob/74993a2a64bb2e423b40204bb54ff749cdd4ef54/src/compiler/moduleNameResolver.ts#L458
+export interface TypeReferenceDirectiveResolutionCache {
+  getOrCreateCacheForDirectory(
+    directoryName: string,
+    redirectedReference?: typescript.ResolvedProjectReference
+  ): Map<
+    string,
+    typescript.ResolvedTypeReferenceDirectiveWithFailedLookupLocations
+  >;
+  clear(): void;
+  update(compilerOptions: typescript.CompilerOptions): void;
+}
 export interface TSInstance {
   compiler: typeof typescript;
   compilerOptions: typescript.CompilerOptions;
@@ -185,6 +227,8 @@ export interface TSInstance {
   appendTsTsxSuffixesIfRequired: (filePath: string) => string;
   loaderOptions: LoaderOptions;
   rootFileNames: Set<string>;
+  moduleResolutionCache?: ModuleResolutionCache;
+  typeReferenceResolutionCache?: TypeReferenceDirectiveResolutionCache;
   /**
    * a cache of all the files
    */

--- a/src/watch-run.ts
+++ b/src/watch-run.ts
@@ -22,6 +22,9 @@ export function makeWatchRun(
 
   return (compiler: webpack.Compiler, callback: (err?: Error) => void) => {
     instance.servicesHost?.clearCache?.();
+    instance.watchHost?.clearCache?.();
+    instance.moduleResolutionCache?.clear();
+    instance.typeReferenceResolutionCache?.clear();
     const promises = [];
     if (instance.loaderOptions.transpileOnly) {
       instance.reportTranspileErrors = true;

--- a/test/comparison-tests/instance/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/instance/expectedOutput-4.1/output.txt
@@ -1,19 +1,19 @@
-    Asset   Size  Chunks             Chunk Names
-bundle.js  4 KiB       a  [emitted]  a
+    Asset      Size  Chunks             Chunk Names
+bundle.js  4.01 KiB       a  [emitted]  a
 Entrypoint a = bundle.js
 Entrypoint b =
-[./a.ts] 276 bytes {a} [built] [failed] [1 error]
-[./b.ts] 276 bytes {b} [built] [failed] [1 error]
+[./a.ts] 273 bytes {a} [built] [failed] [1 error]
+[./b.ts] 273 bytes {b} [built] [failed] [1 error]
 
 ERROR in ./a.ts
-Module build failed (from index.js):
+Module build failed (from /index.js):
 Error: [31mA file specified in tsconfig.json could not be found: i-dont-exist[39m
-    at Object.loader (dist/index.js:18:18)
+    at Object.loader (dist\index.js:18:18)
 
 ERROR in ./b.ts
-Module build failed (from index.js):
+Module build failed (from /index.js):
 Error: [31mA file specified in tsconfig.json could not be found: i-dont-exist[39m
-    at Object.loader (dist/index.js:18:18)
+    at Object.loader (dist\index.js:18:18)
 
 ERROR in chunk b [entry]
 bundle.js

--- a/test/comparison-tests/instance/expectedOutput-transpile-4.1/output.txt
+++ b/test/comparison-tests/instance/expectedOutput-transpile-4.1/output.txt
@@ -1,19 +1,19 @@
     Asset      Size  Chunks             Chunk Names
-bundle.js  4.01 KiB       a  [emitted]  a
+bundle.js  4.02 KiB       a  [emitted]  a
 Entrypoint a = bundle.js
 Entrypoint b =
-[./a.ts] 286 bytes {a} [built] [failed] [1 error]
-[./b.ts] 286 bytes {b} [built] [failed] [1 error]
+[./a.ts] 283 bytes {a} [built] [failed] [1 error]
+[./b.ts] 283 bytes {b} [built] [failed] [1 error]
 
 ERROR in ./a.ts
-Module build failed (from index.js):
+Module build failed (from /index.js):
 Error: [31mA file specified in tsconfig.json could not be found: i-dont-exist[39m
-    at Object.loader (dist/index.js:18:18)
+    at Object.loader (dist\index.js:18:18)
 
 ERROR in ./b.ts
-Module build failed (from index.js):
+Module build failed (from /index.js):
 Error: [31mA file specified in tsconfig.json could not be found: i-dont-exist[39m
-    at Object.loader (dist/index.js:18:18)
+    at Object.loader (dist\index.js:18:18)
 
 ERROR in chunk b [entry]
 bundle.js

--- a/test/comparison-tests/loaderOptionsCaching/app.ts
+++ b/test/comparison-tests/loaderOptionsCaching/app.ts
@@ -1,0 +1,2 @@
+import './submodule-es5';
+import './submodule-es6';

--- a/test/comparison-tests/loaderOptionsCaching/expectedOutput-4.1/bundle.js
+++ b/test/comparison-tests/loaderOptionsCaching/expectedOutput-4.1/bundle.js
@@ -1,0 +1,123 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony import */ var _submodule_es5__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./submodule-es5 */ \"./submodule-es5/index.ts\");\n/* harmony import */ var _submodule_es5__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_submodule_es5__WEBPACK_IMPORTED_MODULE_0__);\n/* harmony import */ var _submodule_es6__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./submodule-es6 */ \"./submodule-es6/index.ts\");\n/* harmony import */ var _submodule_es6__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_submodule_es6__WEBPACK_IMPORTED_MODULE_1__);\n\n\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ }),
+
+/***/ "./submodule-es5/index.ts":
+/*!********************************!*\
+  !*** ./submodule-es5/index.ts ***!
+  \********************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("var string = 'Hello from es5 file';\r\nconsole.log(string);\r\n\n\n//# sourceURL=webpack:///./submodule-es5/index.ts?");
+
+/***/ }),
+
+/***/ "./submodule-es6/index.ts":
+/*!********************************!*\
+  !*** ./submodule-es6/index.ts ***!
+  \********************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("const set = new Set([42]);\r\nfor (const value of set) {\r\n    console.log(value);\r\n}\r\nconst string = 'Hello from es6 file';\r\nconsole.log(string);\r\n\n\n//# sourceURL=webpack:///./submodule-es6/index.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/loaderOptionsCaching/expectedOutput-4.1/output.txt
+++ b/test/comparison-tests/loaderOptionsCaching/expectedOutput-4.1/output.txt
@@ -1,0 +1,6 @@
+    Asset      Size  Chunks             Chunk Names
+bundle.js  5.21 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[./app.ts] 52 bytes {main} [built]
+[./submodule-es5/index.ts] 59 bytes {main} [built]
+[./submodule-es6/index.ts] 145 bytes {main} [built]

--- a/test/comparison-tests/loaderOptionsCaching/expectedOutput-transpile-4.1/bundle.js
+++ b/test/comparison-tests/loaderOptionsCaching/expectedOutput-transpile-4.1/bundle.js
@@ -1,0 +1,123 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = "./app.ts");
+/******/ })
+/************************************************************************/
+/******/ ({
+
+/***/ "./app.ts":
+/*!****************!*\
+  !*** ./app.ts ***!
+  \****************/
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+eval("__webpack_require__.r(__webpack_exports__);\n/* harmony import */ var _submodule_es5__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./submodule-es5 */ \"./submodule-es5/index.ts\");\n/* harmony import */ var _submodule_es5__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_submodule_es5__WEBPACK_IMPORTED_MODULE_0__);\n/* harmony import */ var _submodule_es6__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./submodule-es6 */ \"./submodule-es6/index.ts\");\n/* harmony import */ var _submodule_es6__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(_submodule_es6__WEBPACK_IMPORTED_MODULE_1__);\n\n\n\n\n//# sourceURL=webpack:///./app.ts?");
+
+/***/ }),
+
+/***/ "./submodule-es5/index.ts":
+/*!********************************!*\
+  !*** ./submodule-es5/index.ts ***!
+  \********************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("var string = 'Hello from es5 file';\r\nconsole.log(string);\r\n\n\n//# sourceURL=webpack:///./submodule-es5/index.ts?");
+
+/***/ }),
+
+/***/ "./submodule-es6/index.ts":
+/*!********************************!*\
+  !*** ./submodule-es6/index.ts ***!
+  \********************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+eval("const set = new Set([42]);\r\nfor (const value of set) {\r\n    console.log(value);\r\n}\r\nconst string = 'Hello from es6 file';\r\nconsole.log(string);\r\n\n\n//# sourceURL=webpack:///./submodule-es6/index.ts?");
+
+/***/ })
+
+/******/ });

--- a/test/comparison-tests/loaderOptionsCaching/expectedOutput-transpile-4.1/output.txt
+++ b/test/comparison-tests/loaderOptionsCaching/expectedOutput-transpile-4.1/output.txt
@@ -1,0 +1,6 @@
+    Asset      Size  Chunks             Chunk Names
+bundle.js  5.21 KiB    main  [emitted]  main
+Entrypoint main = bundle.js
+[./app.ts] 52 bytes {main} [built]
+[./submodule-es5/index.ts] 59 bytes {main} [built]
+[./submodule-es6/index.ts] 145 bytes {main} [built]

--- a/test/comparison-tests/loaderOptionsCaching/submodule-es5/index.ts
+++ b/test/comparison-tests/loaderOptionsCaching/submodule-es5/index.ts
@@ -1,0 +1,2 @@
+const string = 'Hello from es5 file';
+console.log(string);

--- a/test/comparison-tests/loaderOptionsCaching/submodule-es5/tsconfig.json
+++ b/test/comparison-tests/loaderOptionsCaching/submodule-es5/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "target": "es5"
+    }
+}

--- a/test/comparison-tests/loaderOptionsCaching/submodule-es6/index.ts
+++ b/test/comparison-tests/loaderOptionsCaching/submodule-es6/index.ts
@@ -1,0 +1,7 @@
+const set = new Set([42]);
+for (const value of set) {
+	console.log(value);
+}
+
+const string = 'Hello from es6 file';
+console.log(string);

--- a/test/comparison-tests/loaderOptionsCaching/submodule-es6/tsconfig.json
+++ b/test/comparison-tests/loaderOptionsCaching/submodule-es6/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "target": "es6"
+    }
+}

--- a/test/comparison-tests/loaderOptionsCaching/tsconfig.json
+++ b/test/comparison-tests/loaderOptionsCaching/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "target": "es5"
+    }
+}

--- a/test/comparison-tests/loaderOptionsCaching/webpack.config.js
+++ b/test/comparison-tests/loaderOptionsCaching/webpack.config.js
@@ -1,0 +1,32 @@
+module.exports = {
+    mode: 'development',
+    entry: './app.ts',
+    output: {
+        filename: 'bundle.js'
+    },
+    resolve: {
+        extensions: ['.ts']
+    },
+    module: {
+        rules: [
+            {
+                test: /submodule-es6.*\.ts$/,
+                loader: 'ts-loader',
+                options: {
+                    compilerOptions: {
+                        target: 'es6',
+                    },
+                },
+            },
+            {
+                test: /submodule-es5.*\.ts$/,
+                loader: 'ts-loader',
+                options: {
+                    compilerOptions: {
+                        target: 'es5',
+                    },
+                },
+            }
+        ]
+    }
+}

--- a/test/comparison-tests/projectReferencesSymLinks/expectedOutput-4.1/patch0/output.txt
+++ b/test/comparison-tests/projectReferencesSymLinks/expectedOutput-4.1/patch0/output.txt
@@ -11,4 +11,4 @@ Entrypoint main = index.js
 ERROR in app/src/index.ts
 ./src/index.ts 1:9-25
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp/src/index.ts(1,10)[39m[22m
-[1m[31m      TS2724: '"../../lib/dist"' has no exported member named 'getMeaningOfLife'. Did you mean 'getMeaningOfLife3'?[39m[22m
+[1m[31m      TS2724: '"../../node_modules/lib/dist"' has no exported member named 'getMeaningOfLife'. Did you mean 'getMeaningOfLife3'?[39m[22m

--- a/test/comparison-tests/projectReferencesSymLinks_WatchApi/expectedOutput-4.1/patch0/output.txt
+++ b/test/comparison-tests/projectReferencesSymLinks_WatchApi/expectedOutput-4.1/patch0/output.txt
@@ -11,4 +11,4 @@ Entrypoint main = index.js
 ERROR in app/src/index.ts
 ./src/index.ts 1:9-25
 [90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp/src/index.ts(1,10)[39m[22m
-[1m[31m      TS2724: '"../../lib/dist"' has no exported member named 'getMeaningOfLife'. Did you mean 'getMeaningOfLife3'?[39m[22m
+[1m[31m      TS2724: '"../../node_modules/lib/dist"' has no exported member named 'getMeaningOfLife'. Did you mean 'getMeaningOfLife3'?[39m[22m

--- a/yarn.lock
+++ b/yarn.lock
@@ -6267,10 +6267,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 uglify-js@3.3.x:
   version "3.3.9"


### PR DESCRIPTION
Compiles against 4.6.3 - a starting point for the backport to webpack 4 to fix #1421 with TypeScript 4.7.  See discussion with @dragomirtitian here: #1422

If the changes of #1422 are implemented - just `servicesHost.ts` and `interfaces.ts` I think, then this should be enough to get it working with webpack 4.