### PR TITLE
Resolve Type References (TypeScript 4.7) for webpack 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "mocha": "^6.0.0",
     "prettier": "^2.0.5",
     "rimraf": "^2.6.2",
-    "typescript": "^4.0.0",
+    "typescript": "^4.6.3",
     "webpack": "^4.5.0",
     "webpack-cli": "^3.1.1"
   },

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -378,6 +378,7 @@ export function initializeInstance(
   } else if (typeof customerTransformers === 'string') {
     try {
       customerTransformers = require(customerTransformers);
+      // eslint-disable-next-line prettier/prettier
     } catch (err) {
       throw new Error(
         `Failed to load customTransformers from "${instance.loaderOptions.getCustomTransformers}": ${err.message}`

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -198,6 +198,7 @@ interface PerModuleNameCache {
     result: typescript.ResolvedModuleWithFailedLookupLocations
   ): void;
 }
+
 export interface ModuleResolutionCache
   extends typescript.ModuleResolutionCache {
   directoryToModuleNameMap: CacheWithRedirects<
@@ -206,8 +207,8 @@ export interface ModuleResolutionCache
   moduleNameToDirectoryMap: CacheWithRedirects<PerModuleNameCache>;
   clear(): void;
   update(compilerOptions: typescript.CompilerOptions): void;
-  getPackageJsonInfoCache?(): any;
 }
+
 // Until the API has been released and ts-loader is built against a version of TypeScript that contains it - see https://github.com/microsoft/TypeScript/blob/74993a2a64bb2e423b40204bb54ff749cdd4ef54/src/compiler/moduleNameResolver.ts#L458
 export interface TypeReferenceDirectiveResolutionCache {
   getOrCreateCacheForDirectory(

--- a/yarn.lock
+++ b/yarn.lock
@@ -6267,10 +6267,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 uglify-js@3.3.x:
   version "3.3.9"


### PR DESCRIPTION
Compiles against 4.6.3 - a starting point for the backport to webpack 4 to fix #1421 with TypeScript 4.7.  See discussion with @dragomirtitian here: #1422

If the changes of #1422 are implemented - just `servicesHost.ts` and `interfaces.ts` I think, then this should be enough to get it working with webpack 4.