### PR TITLE
fix: cater for change in resolveTypeReferenceDirective API in 4.7

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         node: [12, 14]
-        ts: [3.8.3, 3.9.3, 4.0.3, 4.1.5, next]
+        ts: [3.8.3, 3.9.3, 4.0.3, 4.1.5, 4.2.4, 4.3.2, 4.4.2, 4.5.2, next]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         node: [12, 14]
-        ts: [3.8.3, 3.9.3, 4.0.3, 4.1.5, next]
+        ts: [3.8.3, 3.9.3, 4.0.3, 4.1.5, 4.2.4, 4.3.2, 4.4.2, 4.5.2, next]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v8.4.0
+
+* [fix: cater for change in resolveTypeReferenceDirective API in 4.7](https://github.com/TypeStrong/ts-loader/pull/1446) - thanks @dragomirtitian
+* This is a backport from v9.2.7 for webpack 4 compatibility
+
 ## v8.3.0
 
 * [Fixed impossibility to have several instances of ts-loader with different compiler options](https://github.com/TypeStrong/ts-loader/issues/1316) - thanks @timocov

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "mocha": "^6.0.0",
     "prettier": "^2.0.5",
     "rimraf": "^2.6.2",
-    "typescript": "^4.0.0",
+    "typescript": "^4.6.3",
     "webpack": "^4.5.0",
     "webpack-cli": "^3.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -378,10 +378,11 @@ export function initializeInstance(
   } else if (typeof customerTransformers === 'string') {
     try {
       customerTransformers = require(customerTransformers);
-      // eslint-disable-next-line prettier/prettier
     } catch (err) {
       throw new Error(
-        `Failed to load customTransformers from "${instance.loaderOptions.getCustomTransformers}": ${err.message}`
+        `Failed to load customTransformers from "${
+          instance.loaderOptions.getCustomTransformers
+        }": ${err instanceof Error ? err.message : ''}`
       );
     }
 

--- a/src/instances.ts
+++ b/src/instances.ts
@@ -378,6 +378,7 @@ export function initializeInstance(
   } else if (typeof customerTransformers === 'string') {
     try {
       customerTransformers = require(customerTransformers);
+      // eslint-disable-next-line prettier/prettier
     } catch (err) {
       throw new Error(
         `Failed to load customTransformers from "${instance.loaderOptions.getCustomTransformers}": ${err.message}`

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -198,6 +198,7 @@ interface PerModuleNameCache {
     result: typescript.ResolvedModuleWithFailedLookupLocations
   ): void;
 }
+
 export interface ModuleResolutionCache
   extends typescript.ModuleResolutionCache {
   directoryToModuleNameMap: CacheWithRedirects<
@@ -206,8 +207,8 @@ export interface ModuleResolutionCache
   moduleNameToDirectoryMap: CacheWithRedirects<PerModuleNameCache>;
   clear(): void;
   update(compilerOptions: typescript.CompilerOptions): void;
-  getPackageJsonInfoCache?(): any;
 }
+
 // Until the API has been released and ts-loader is built against a version of TypeScript that contains it - see https://github.com/microsoft/TypeScript/blob/74993a2a64bb2e423b40204bb54ff749cdd4ef54/src/compiler/moduleNameResolver.ts#L458
 export interface TypeReferenceDirectiveResolutionCache {
   getOrCreateCacheForDirectory(

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -209,18 +209,6 @@ export interface ModuleResolutionCache
   update(compilerOptions: typescript.CompilerOptions): void;
 }
 
-// Until the API has been released and ts-loader is built against a version of TypeScript that contains it - see https://github.com/microsoft/TypeScript/blob/74993a2a64bb2e423b40204bb54ff749cdd4ef54/src/compiler/moduleNameResolver.ts#L458
-export interface TypeReferenceDirectiveResolutionCache {
-  getOrCreateCacheForDirectory(
-    directoryName: string,
-    redirectedReference?: typescript.ResolvedProjectReference
-  ): Map<
-    string,
-    typescript.ResolvedTypeReferenceDirectiveWithFailedLookupLocations
-  >;
-  clear(): void;
-  update(compilerOptions: typescript.CompilerOptions): void;
-}
 export interface TSInstance {
   compiler: typeof typescript;
   compilerOptions: typescript.CompilerOptions;
@@ -229,7 +217,7 @@ export interface TSInstance {
   loaderOptions: LoaderOptions;
   rootFileNames: Set<string>;
   moduleResolutionCache?: ModuleResolutionCache;
-  typeReferenceResolutionCache?: TypeReferenceDirectiveResolutionCache;
+  typeReferenceResolutionCache?: typescript.TypeReferenceDirectiveResolutionCache;
   /**
    * a cache of all the files
    */
@@ -360,6 +348,31 @@ export interface ResolvedModule {
   resolvedFileName: string;
   resolvedModule?: ResolvedModule;
   isExternalLibraryImport?: boolean;
+}
+
+export interface TSCommon {
+  // Changed in TS 4.7
+  resolveTypeReferenceDirective(
+    typeReferenceDirectiveName: string,
+    containingFile: string | undefined,
+    options: typescript.CompilerOptions,
+    host: typescript.ModuleResolutionHost,
+    redirectedReference?: typescript.ResolvedProjectReference,
+    cache?: typescript.TypeReferenceDirectiveResolutionCache,
+    resolutionMode?: typescript.SourceFile['impliedNodeFormat']
+  ): typescript.ResolvedTypeReferenceDirectiveWithFailedLookupLocations;
+}
+
+/**
+ * Compiler APIs we use that are marked internal and not included in TypeScript's public API declarations
+ * @internal
+ */
+export interface TSInternal {
+  // Added in TS 4.7
+  getModeForFileReference?: (
+    ref: typescript.FileReference | string,
+    containingFileMode: typescript.SourceFile['impliedNodeFormat']
+  ) => typescript.SourceFile['impliedNodeFormat'];
 }
 
 export type Severity = 'error' | 'warning';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6267,10 +6267,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 uglify-js@3.3.x:
   version "3.3.9"


### PR DESCRIPTION
fix: cater for change in resolveTypeReferenceDirective API in TypeScript 4.7
