### PR TITLE
Hotfix: Disable `enhanced-resolve`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.4.1
+* [Hotfix: Disable `enhanced-resolve`](https://github.com/TypeStrong/ts-loader/pull/1505) - thanks @manuth
+
 ## v9.4.0
 
 * [Add Support for Resolving `.cjs`, `.mjs`, `.cts` and `.mts` Files](https://github.com/TypeStrong/ts-loader/pull/1503) [#1503] - thanks @manuth 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "9.4.0",
+  "version": "9.4.1",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,11 +1,15 @@
 import type * as webpack from 'webpack';
 
-import { create } from 'enhanced-resolve';
+import { create as _create } from 'enhanced-resolve';
 
 export function makeResolver(
-  options: webpack.WebpackOptionsNormalized
+  _options: webpack.WebpackOptionsNormalized
 ): ResolveSync {
-  return create.sync(options.resolve);
+  /* Currently, `enhanced-resolve` does not work properly alongside `ts-loader`.
+   * This feature is disabled until a proper worflow has been worked out. */
+  return (_context, _path, _moduleName?): string | false => {
+    throw new Error();
+  };
 }
 
 export type ResolveSync = {

--- a/test/comparison-tests/aliasResolution/expectedOutput-4.8/output.txt
+++ b/test/comparison-tests/aliasResolution/expectedOutput-4.8/output.txt
@@ -1,6 +1,12 @@
 asset bundle.js 2.6 KiB [emitted] (name: main)
-./app.ts 120 bytes [built] [code generated] [1 error]
+./app.ts 120 bytes [built] [code generated] [2 errors]
 ./common/components/myComponent.ts 46 bytes [built] [code generated]
+
+ERROR in app.ts
+./app.ts 1:29-53
+[90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(1,30)[39m[22m
+[1m[31m      TS2307: Cannot find module 'components/myComponent' or its corresponding type declarations.[39m[22m
+ts-loader-default_609318b4f68865d3
 
 ERROR in app.ts
 ./app.ts 2:30-55
@@ -8,4 +14,4 @@ ERROR in app.ts
 [1m[31m      TS2307: Cannot find module 'components/myComponent2' or its corresponding type declarations.[39m[22m
 ts-loader-default_609318b4f68865d3
 
-webpack compiled with 1 error
+webpack compiled with 2 errors

--- a/test/comparison-tests/aliasResolution/expectedOutput-4.8/patch0/output.txt
+++ b/test/comparison-tests/aliasResolution/expectedOutput-4.8/patch0/output.txt
@@ -1,6 +1,12 @@
 asset bundle.js 2.6 KiB [emitted] (name: main)
-./app.ts 120 bytes [built] [code generated] [1 error]
+cached modules 120 bytes [cached] 1 module
 ./common/components/myComponent.ts 45 bytes [built] [code generated]
+
+ERROR in app.ts
+./app.ts 1:29-53
+[90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(1,30)[39m[22m
+[1m[31m      TS2307: Cannot find module 'components/myComponent' or its corresponding type declarations.[39m[22m
+ts-loader-default_609318b4f68865d3
 
 ERROR in app.ts
 ./app.ts 2:30-55
@@ -8,4 +14,4 @@ ERROR in app.ts
 [1m[31m      TS2307: Cannot find module 'components/myComponent2' or its corresponding type declarations.[39m[22m
 ts-loader-default_609318b4f68865d3
 
-webpack compiled with 1 error
+webpack compiled with 2 errors

--- a/test/comparison-tests/errorFormatter/expectedOutput-4.8/output.txt
+++ b/test/comparison-tests/errorFormatter/expectedOutput-4.8/output.txt
@@ -1,10 +1,15 @@
 asset bundle.js 2.6 KiB [emitted] (name: main)
-./app.ts 120 bytes [built] [code generated] [1 error]
+./app.ts 120 bytes [built] [code generated] [2 errors]
 ./common/components/myComponent.ts 46 bytes [built] [code generated]
+
+ERROR in app.ts
+./app.ts 1:29-53
+Does not compute.... [1m[31mcode: 2307,severity: error,content: Cannot find module 'components/myComponent' or its corresponding type declarations.,file: app.ts,line: 1,character: 30,context: .test/errorFormatter[39m[22m
+ts-loader-default_85b0565984bbe8dd
 
 ERROR in app.ts
 ./app.ts 2:30-55
 Does not compute.... [1m[31mcode: 2307,severity: error,content: Cannot find module 'components/myComponent2' or its corresponding type declarations.,file: app.ts,line: 2,character: 31,context: .test/errorFormatter[39m[22m
 ts-loader-default_85b0565984bbe8dd
 
-webpack compiled with 1 error
+webpack compiled with 2 errors

--- a/test/comparison-tests/localTsImplementationOfTypings/expectedOutput-4.8/output.txt
+++ b/test/comparison-tests/localTsImplementationOfTypings/expectedOutput-4.8/output.txt
@@ -1,4 +1,11 @@
 asset bundle.js 2.59 KiB [emitted] (name: main)
-./app.ts 101 bytes [built] [code generated]
+./app.ts 101 bytes [built] [code generated] [1 error]
 ./fake.ts 165 bytes [built] [code generated]
-webpack compiled successfully
+
+ERROR in app.ts
+./app.ts 1:29-34
+[90m[tsl] [39m[1m[31mERROR[39m[22m[1m[31m in [39m[22m[1m[36mapp.ts(1,30)[39m[22m
+[1m[31m      TS2307: Cannot find module 'api' or its corresponding type declarations.[39m[22m
+ts-loader-default_609318b4f68865d3
+
+webpack compiled with 1 error


### PR DESCRIPTION
As discussed in #1503, #1505 and #1504, `enhanced-resolve` causes issues in case both `typescript` and `enhanced-resolve` are able to resolve a module specifier.

Changes made in this PR will disable `enhanced-resolve`. This change might be reverted once a proper workflow has been worked out.

In doing so, this PR will fix #1505 and fix #1504.

This is a follow-up to PR #1503 which introduced the changes causing these issues.