### PR TITLE
Raise an error when config file is specified but not found

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,10 @@ export function getConfigFile(
       )[0];
     }
   } else {
+    if (loaderOptions.configFile !== undefined) {
+      configFileError = new Error(`Cannot find '${loaderOptions.configFile }' in folder '${path.dirname(loader.resourcePath)}'`);
+    }
+
     if (compilerCompatible) {
       log.logInfo(compilerDetailsLogMessage);
     }


### PR DESCRIPTION
Hi!

A small contribution to explicitly raise an error if user specify a configuration file that cannot be resolved/found.

Please let me know:
* if it makes sense :-)
* if it is the right approach (I've tried to use the `formatErrors` utils but didn't seem to work in this case)
* how I can test it (not sure where to put the test)

Thanks!!