### PR TITLE
Update changelog for version 9.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## 9.5.3
+## 9.5.4
 * [chore: typescript 5.9 upgrade](https://github.com/TypeStrong/ts-loader/pull/1676) - thanks @johnnyreilly
+
+Skipping 9.5.3 due to a publishing issue
 
 ## 9.5.2
 * [fix: add more detailed error messages](https://github.com/TypeStrong/ts-loader/pull/1665) - thanks @hai-x


### PR DESCRIPTION
As the tag for 9.5.3 was taken due to a publishing issue with 9.5.2