### PR TITLE
fix: rspack support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.6.1
+* [fix: rspack support](https://github.com/TypeStrong/ts-loader/pull/1699) - thanks @johnnyreilly and @bhollis
+
 ## 9.6.0
 * [feat: add webpack 4 support back](https://github.com/TypeStrong/ts-loader/pull/1697) - thanks @johnnyreilly and @tweet
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-loader",
-  "version": "9.6.0",
+  "version": "9.6.1",
   "description": "TypeScript loader for webpack",
   "main": "index.js",
   "types": "dist",

--- a/src/after-compile.ts
+++ b/src/after-compile.ts
@@ -476,12 +476,12 @@ function removeModuleTSLoaderError(
   module: webpack.Module,
   loaderOptions: LoaderOptions
 ) {
-  if (isWebpack5) {
+  if (isWebpack5 && module.getWarnings) {
     const warnings = Array.from(
-      module.getWarnings() || (module.warnings as webpack.WebpackError[]) || []
+      module.getWarnings() || []
     );
     const errors = Array.from(
-      module.getErrors() || (module.errors as webpack.WebpackError[]) || []
+      module.getErrors() || []
     );
     module.clearWarningsAndErrors();
     warnings.forEach(warning => {

--- a/src/after-compile.ts
+++ b/src/after-compile.ts
@@ -478,10 +478,10 @@ function removeModuleTSLoaderError(
 ) {
   if (isWebpack5) {
     const warnings = Array.from(
-      module.getWarnings() || []
+      module.getWarnings() || (module.warnings as webpack.WebpackError[]) || []
     );
     const errors = Array.from(
-      module.getErrors() || []
+      module.getErrors() || (module.errors as webpack.WebpackError[]) || []
     );
     module.clearWarningsAndErrors();
     warnings.forEach(warning => {


### PR DESCRIPTION
See https://github.com/TypeStrong/ts-loader/issues/1698

ts-loader had not intentionally supported rspack, but since it worked with earlier versions of ts-loader, it seems good to make it work again. There's a tiny feature detection tweak in this PR which should fix compatibility.

I'd quite like a more explicit test for using rspack but this seems perfectly fine 