### PR TITLE
chore: remove semver from dependencies field

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "chalk": "^4.1.0",
     "enhanced-resolve": "^5.0.0",
     "micromatch": "^4.0.0",
-    "semver": "^7.3.4",
     "source-map": "^0.7.4"
   },
   "devDependencies": {
@@ -92,6 +91,7 @@
     "mocha": "^6.0.0",
     "prettier": "^2.0.5",
     "rimraf": "^2.6.2",
+    "semver": "^7.3.4",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.59.4",
     "webpack": "^5.74.0",

--- a/src/compilerSetup.ts
+++ b/src/compilerSetup.ts
@@ -27,8 +27,7 @@ export function getCompiler(loaderOptions: LoaderOptions, log: logger.Logger) {
       if (compiler!.version !== undefined) {
         const [major, minor, patch] = compiler!.version
           .split(".")
-          // Avoid NaN
-          .map(part => Number(part) || 0);
+          .map(Number);
         // >= 3.6.3
         const compareScore = major - 3 || minor - 6 || patch - 3;
         if (compareScore >= 0) {

--- a/src/compilerSetup.ts
+++ b/src/compilerSetup.ts
@@ -1,4 +1,3 @@
-import * as semver from 'semver';
 import type typescript from 'typescript';
 
 import type { LoaderOptions } from './interfaces';
@@ -25,12 +24,17 @@ export function getCompiler(loaderOptions: LoaderOptions, log: logger.Logger) {
     }`;
     compilerCompatible = false;
     if (loaderOptions.compiler === 'typescript') {
-      if (
-        compiler!.version !== undefined &&
-        semver.gte(compiler!.version, '3.6.3')
-      ) {
-        // don't log yet in this case, if a tsconfig.json exists we want to combine the message
-        compilerCompatible = true;
+      if (compiler!.version !== undefined) {
+        const [major, minor, patch] = compiler!.version
+          .split(".")
+          // Avoid NaN
+          .map(part => Number(part) || 0);
+        // >= 3.6.3
+        const compareScore = major - 3 || minor - 6 || patch - 3;
+        if (compareScore >= 0) {
+          // don't log yet in this case, if a tsconfig.json exists we want to combine the message
+          compilerCompatible = true;
+        }
       } else {
         log.logError(
           `${compilerDetailsLogMessage}. This version is incompatible with ts-loader. Please upgrade to the latest version of TypeScript.`


### PR DESCRIPTION
We only use `.gte` method from `semver` package on end-user code. Which can be written like this.

```text
score = current - expected
if (score >= 0):
  return true;
```
