### PR TITLE
fix: bound benchmark scenario wall-clock time to fit CI's job timeout

### DIFF
--- a/test/benchmark-tests/run-benchmark.mts
+++ b/test/benchmark-tests/run-benchmark.mts
@@ -184,6 +184,7 @@ function runSideProcess({ root, meta, outputPath, transpileOnly, scenarioType, w
     '--transpile-only', String(transpileOnly),
     '--scenario-type', scenarioType,
     '--iterations', String(warmup + iterations),
+    '--warmup', String(warmup),
     ...(scenarioType !== 'cold' ? [
       '--touch-file', meta.touch[scenarioType].file,
       '--touch-original', touchOriginalPath,

--- a/test/benchmark-tests/run-side.mts
+++ b/test/benchmark-tests/run-side.mts
@@ -18,6 +18,7 @@
  *   --touch-file    <path>   file to touch (incremental scenarios only)
  *   --touch-original <path>  file containing original content (incremental scenarios only)
  *   --iterations    <n>      total number of iterations (warmup + measured)
+ *   --warmup        <n>      warmup iterations already included in --iterations
  */
 
 import fs from 'node:fs';
@@ -25,6 +26,17 @@ import { buildWebpackConfig, runColdBuild, createWatchSession, withTimeout, touc
 
 const INITIAL_BUILD_TIMEOUT_MS = 120_000;
 const REBUILD_TIMEOUT_MS = 30_000;
+// Per-scenario wall-clock cap, applied only after --warmup + MIN_MEASURED_ITERATIONS
+// samples are in hand. --iterations Ă— multiplier (see run-benchmark.mts) assumes a
+// cheap-to-instantiate compiler; a sync-API compiler that spawns a native child
+// process per instance (e.g. tsgo) or does per-dependant round trips for a
+// wide-fanout touch (e.g. a hub file imported by most of the fixture) can be
+// 10-100x more expensive per iteration, which would otherwise blow the CI job's
+// timeout long before every scenario finishes. Capping wall-clock instead of
+// guessing a smaller fixed iteration count keeps full statistical power for
+// scenarios that stay cheap while still bounding the expensive ones.
+const SCENARIO_TIME_BUDGET_MS = 60_000;
+const MIN_MEASURED_ITERATIONS = 2;
 
 function get(flag: string): string {
   const argv = process.argv;
@@ -44,6 +56,7 @@ async function main(): Promise<void> {
   const transpileOnly = get('--transpile-only') === 'true';
   const scenarioType = get('--scenario-type') as 'cold' | 'leaf' | 'hub';
   const iterations = Number(get('--iterations'));
+  const warmup = Number(get('--warmup'));
 
   const config = buildWebpackConfig({
     fixtureDir,
@@ -55,11 +68,32 @@ async function main(): Promise<void> {
   });
 
   const durations: number[] = [];
+  const minIterationsBeforeBudgetCutoff = warmup + MIN_MEASURED_ITERATIONS;
+
+  /**
+   * True once enough samples exist to slice off `warmup` and still leave
+   * MIN_MEASURED_ITERATIONS measured ones, AND the scenario has run past its
+   * wall-clock budget - i.e. safe to stop early. `loopStart` excludes the
+   * (untimed) initial/watch-session build above.
+   */
+  function pastBudget(count: number, loopStart: number): boolean {
+    return (
+      count >= minIterationsBeforeBudgetCutoff &&
+      Date.now() - loopStart >= SCENARIO_TIME_BUDGET_MS
+    );
+  }
 
   if (scenarioType === 'cold') {
+    const loopStart = Date.now();
     for (let i = 0; i < iterations; i++) {
       const ms = await withTimeout(runColdBuild(config), INITIAL_BUILD_TIMEOUT_MS, `cold build iteration ${i}`);
       durations.push(ms);
+      if (pastBudget(durations.length, loopStart)) {
+        console.error(
+          `run-side: cold ${transpileOnly ? 'transpileOnly' : 'typeCheck'} stopped early after ${durations.length}/${iterations} iterations (${SCENARIO_TIME_BUDGET_MS}ms budget)`,
+        );
+        break;
+      }
     }
   } else {
     const touchFilePath = get('--touch-file');
@@ -76,10 +110,17 @@ async function main(): Promise<void> {
       `initial build for ${label}`
     );
     try {
+      const loopStart = Date.now();
       for (let i = 0; i < iterations; i++) {
         const pending = withTimeout(session.nextCompile(), REBUILD_TIMEOUT_MS, `${label} iteration ${i}`);
         touchFile(touchFilePath, touchOriginal, i);
         durations.push(await pending);
+        if (pastBudget(durations.length, loopStart)) {
+          console.error(
+            `run-side: ${label} (${transpileOnly ? 'transpileOnly' : 'typeCheck'}) stopped early after ${durations.length}/${iterations} iterations (${SCENARIO_TIME_BUDGET_MS}ms budget)`,
+          );
+          break;
+        }
       }
     } finally {
       await session.close();


### PR DESCRIPTION
## Summary

Ports the wall-clock safety cap from the `copilot/implement-new-tsgo-api-support` branch's benchmark harness (commit b9efbc4e) onto `main`, so both branches' benchmark mechanisms match.

- Caps each benchmark scenario's wall-clock time in `run-side.mts` (60s, after a minimum sample floor) instead of relying solely on a fixed iteration count.
- Cheap scenarios are unaffected (they already finish under the cap); scenarios with an unexpectedly high per-iteration cost stop once they've collected enough measured samples, rather than risking the whole job blowing past the 20-minute CI timeout.
- On `main` today (classic ts-loader, cheap in-process instantiation) this cap essentially never triggers - verified with a local run against this branch's own checkout, where every scenario completed at its full iteration count with no early cutoff. It's here as a safety net: if a future change (here or in a dependency) makes some scenario meaningfully more expensive per iteration, the benchmark degrades gracefully (fewer samples, still reports) instead of timing out with no results at all - exactly what happened on the tsgo branch before this cap was added there.

## Test plan

- [x] `yarn lint` passes
- [x] `yarn build` passes (TypeScript 6.0.2)
- [x] `npx tsc --project test/benchmark-tests/tsconfig.json --noEmit` passes
- [x] Ran `node test/benchmark-tests/run-benchmark.mts` locally (self-comparison) - all 6 scenarios completed at full iteration count, no early cutoffs, deltas near zero as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)